### PR TITLE
feat/fix: 迁移搜索引擎至 UAPI 并修复 CloudFlare AI 接口适配

### DIFF
--- a/src/main/java/org/YanPl/api/CloudFlareAI.java
+++ b/src/main/java/org/YanPl/api/CloudFlareAI.java
@@ -188,6 +188,7 @@ public class CloudFlareAI {
             plugin.getLogger().info("[AI Response] Code: " + response.code());
 
             if (!response.isSuccessful()) {
+                plugin.getLogger().warning("[AI Error] Response Body: " + responseBody);
                 throw new IOException("AI 调用失败: " + response.code() + " - " + responseBody);
             }
 

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -706,8 +706,8 @@ public class CLIManager {
             String url = "https://uapis.cn/api/v1/search/aggregate";
             
             com.google.gson.JsonObject bodyJson = new com.google.gson.JsonObject();
-            // 参数名确认为 querystring
-            bodyJson.addProperty("querystring", query);
+            // 参数名确认为 query
+            bodyJson.addProperty("query", query);
             
             okhttp3.RequestBody body = okhttp3.RequestBody.create(
                 bodyJson.toString(),


### PR DESCRIPTION
### 变更摘要
本次 PR 主要完成了搜索引擎接口的迁移（从 DuckDuckGo 迁移至 UAPI），并针对 CloudFlare AI 接口进行了深度适配、参数修复及错误处理优化，以提高系统的稳定性和兼容性。

### 详细变更列表 1. 搜索引擎迁移 ( CLIManager.java )
- 变更内容 : 将公开搜索接口从 DuckDuckGo 迁移至 UAPI。
- 原因 : 优化搜索服务的可用性和响应质量（根据 08140e6 提交）。 2. CloudFlare AI 接口适配与修复 ( CloudFlareAI.java )
- API 端点更新 : 更新了 API 端点以适配最新的 CloudFlare AI 服务 ( 36dbd8d )。
- 响应格式适配 : 修改了解析逻辑以适配新的 API 响应格式 ( 36dbd8d )。
- 参数修复 : 修复了 API 请求参数构造问题，确保请求符合接口规范 ( 3a9bb4c )。
- 错误处理增强 :
  - 优化了错误捕获逻辑，提升了接口的健壮性 ( b314299 )。
  - 新增了在 AI 调用失败时记录完整响应体的功能，便于排查问题 ( fd4880d )。
### 关联提交 (Commits)
- fd4880d fix(CloudFlareAI): 在AI调用失败时记录响应体
- 3a9bb4c fix(api): 修复API请求参数并改进错误处理
- 36dbd8d refactor(CloudFlareAI): 更新API端点并适配新的响应格式
- b314299 fix(api): 修复CloudFlare AI接口兼容性问题并优化错误处理
- 08140e6 feat(CLIManager): 将公开搜索接口从DuckDuckGo迁移至UAPI
### 测试计划
- 验证 CLIManager 中的搜索功能是否能通过 UAPI 正常返回结果。
- 验证 CloudFlareAI 是否能成功调用模型并解析返回内容。
- 模拟 AI 调用失败场景，检查日志中是否正确记录了响应体。