### PR TITLE
ci: 提前创建Git标签以避免自动创建失败

### DIFF
--- a/.github/workflows/CI-Build-Release.yml
+++ b/.github/workflows/CI-Build-Release.yml
@@ -145,6 +145,28 @@ jobs:
         id: safe_ref_name
         run: echo "SAFE_REF_NAME=$(echo ${{ github.ref_name }} | sed 's|/|-|g')" >> $GITHUB_OUTPUT
 
+      # 提前创建 Tag 以防止 Action 自动创建失败 (500 Error 规避)
+      - name: Create Git Tag
+        if: steps.check_release.outputs.IS_RELEASE == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        run: |
+          TAG_NAME=""
+          if [[ "${{ steps.check_release.outputs.IS_RELEASE }}" == "true" ]]; then
+            TAG_NAME="v${{ steps.check_release.outputs.RELEASE_VERSION }}"
+          else
+            TAG_NAME="master-${{ steps.sha.outputs.SHORT_SHA }}"
+          fi
+          
+          # 检查标签是否已存在
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists."
+          else
+            echo "Creating tag $TAG_NAME"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag $TAG_NAME
+            git push origin $TAG_NAME
+          fi
+
       # 原有逻辑-上传快照包
       - name: 上传快照包
         if: (github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch'
@@ -166,19 +188,25 @@ jobs:
         if: steps.check_release.outputs.IS_RELEASE == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: target/FancyHelper-*.jar
           tag_name: v${{ steps.check_release.outputs.RELEASE_VERSION }}
           name: Release v${{ steps.check_release.outputs.RELEASE_VERSION }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: true
+          make_latest: true
 
       # 原有逻辑-发布预览Release
       - name: 发布预览 Release
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.check_release.outputs.IS_RELEASE != 'true'
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: target/FancyHelper-*.jar
           tag_name: master-${{ steps.sha.outputs.SHORT_SHA }}
           name: Pre-Release ${{ steps.sha.outputs.SHORT_SHA }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: true
           generate_release_notes: true
+          make_latest: false


### PR DESCRIPTION
添加手动创建Git标签的步骤，防止GitHub Actions因500错误导致发布失败。同时为release步骤显式指定token和target_commitish参数，确保操作可靠性。