### PR TITLE
feat(eula): 添加 EULA 管理功能并集成至用户协议流程

### DIFF
--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -4,6 +4,7 @@ import org.YanPl.command.CLICommand;
 import org.YanPl.listener.ChatListener;
 import org.YanPl.manager.CLIManager;
 import org.YanPl.manager.ConfigManager;
+import org.YanPl.manager.EulaManager;
 import org.YanPl.manager.UpdateManager;
 import org.YanPl.manager.WorkspaceIndexer;
 import org.YanPl.util.CloudErrorReport;
@@ -19,6 +20,7 @@ public final class FancyHelper extends JavaPlugin {
     private WorkspaceIndexer workspaceIndexer;
     private CLIManager cliManager;
     private UpdateManager updateManager;
+    private EulaManager eulaManager;
     private CloudErrorReport cloudErrorReport;
 
     @Override
@@ -28,6 +30,9 @@ public final class FancyHelper extends JavaPlugin {
 
         // 执行旧插件清理（清理带有 mineagent 关键词的文件）
         cleanOldPluginFiles();
+
+        // 初始化 EULA 管理器（优先于配置，以便更新时强制替换 EULA）
+        eulaManager = new EulaManager(this);
 
         // 初始化配置管理器
         configManager = new ConfigManager(this);
@@ -73,7 +78,6 @@ public final class FancyHelper extends JavaPlugin {
         if (pluginsDir == null || !pluginsDir.exists() || !pluginsDir.isDirectory()) {
             return;
         }
-
         java.io.File oldDir = new java.io.File(getDataFolder(), "old");
         java.io.File[] targets = pluginsDir.listFiles((dir, name) -> {
             // 正则匹配包含 mineagent (不区分大小写)，且排除 "old" 文件夹本身
@@ -150,6 +154,11 @@ public final class FancyHelper extends JavaPlugin {
             cliManager.shutdown();
         }
 
+        // 关闭 EULA 管理器，释放监听资源
+        if (eulaManager != null) {
+            eulaManager.shutdown();
+        }
+
         // 等待短暂时间以确保后台任务结束
         try {
             Thread.sleep(500);
@@ -174,6 +183,10 @@ public final class FancyHelper extends JavaPlugin {
 
     public UpdateManager getUpdateManager() {
         return updateManager;
+    }
+
+    public EulaManager getEulaManager() {
+        return eulaManager;
     }
 
     public CloudErrorReport getCloudErrorReport() {

--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -88,6 +88,9 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "agree":
                 plugin.getCliManager().handleChat(player, "agree");
                 return true;
+            case "read":
+                plugin.getCliManager().openEulaBook(player);
+                return true;
             case "thought":
                 plugin.getCliManager().handleThought(player, Arrays.copyOfRange(args, 1, args.length));
                 return true;
@@ -121,7 +124,8 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         if (args.length == 1) {
             plugin.getConfigManager().loadConfig();
             plugin.getWorkspaceIndexer().indexAll();
-            player.sendMessage(ChatColor.GREEN + "配置与工作区已重新加载。");
+            plugin.getEulaManager().reload();
+            player.sendMessage(ChatColor.GREEN + "配置、工作区与 EULA 已重新加载。");
         } else if (args.length == 2) {
             String target = args[1].toLowerCase();
             if (target.equals("workspace")) {
@@ -130,6 +134,9 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             } else if (target.equals("config")) {
                 plugin.getConfigManager().loadConfig();
                 player.sendMessage(ChatColor.GREEN + "配置文件已重新加载。");
+            } else if (target.equals("eula")) {
+                plugin.getEulaManager().reload();
+                player.sendMessage(ChatColor.GREEN + "EULA 文件已重新加载。");
             } else if (target.equals("deeply")) {
                 player.sendMessage(ChatColor.YELLOW + "正在深度重载插件...");
                 org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
@@ -166,12 +173,12 @@ public class CLICommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            List<String> subCommands = new ArrayList<>(Arrays.asList("reload", "status", "yolo", "normal", "checkupdate", "upgrade"));
+            List<String> subCommands = new ArrayList<>(Arrays.asList("reload", "status", "yolo", "normal", "checkupdate", "upgrade", "read"));
             return subCommands.stream()
                     .filter(s -> s.startsWith(args[0].toLowerCase()))
                     .collect(Collectors.toList());
         } else if (args.length == 2 && args[0].equalsIgnoreCase("reload")) {
-            return Arrays.asList("workspace", "config", "deeply").stream()
+            return Arrays.asList("workspace", "config", "eula", "deeply").stream()
                     .filter(s -> s.startsWith(args[1].toLowerCase()))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/org/YanPl/listener/ChatListener.java
+++ b/src/main/java/org/YanPl/listener/ChatListener.java
@@ -7,22 +7,88 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import java.lang.reflect.Method;
+
 public class ChatListener implements Listener {
     private final FancyHelper plugin;
+    private static boolean paperChatEventExists = false;
+
+    static {
+        try {
+            Class.forName("io.papermc.paper.event.player.AsyncChatEvent");
+            paperChatEventExists = true;
+        } catch (ClassNotFoundException ignored) {}
+    }
 
     public ChatListener(FancyHelper plugin) {
         this.plugin = plugin;
+        if (paperChatEventExists) {
+            registerPaperChatListener();
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
-        Player player = event.getPlayer();
-        String message = event.getMessage();
-
-        // 如果 CLIManager 处理了该聊天（即处于 CLI 模式），则拦截该消息
-        if (plugin.getCliManager().handleChat(player, message)) {
+        // 如果是 Paper 环境且我们已经注册了现代监听器，则跳过此事件以避免重复处理
+        if (paperChatEventExists) return;
+        
+        handleChatInternal(event.getPlayer(), event.getMessage(), () -> {
             event.getRecipients().clear();
             event.setCancelled(true);
+        });
+    }
+
+    /**
+     * 使用反射手动注册 Paper 的 AsyncChatEvent，以避免直接引用类导致的编译或加载问题
+     * 同时也避开了 @EventHandler 无法标记基类 Event 的限制
+     */
+    private void registerPaperChatListener() {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<? extends org.bukkit.event.Event> asyncChatEventClass = 
+                (Class<? extends org.bukkit.event.Event>) Class.forName("io.papermc.paper.event.player.AsyncChatEvent");
+            
+            plugin.getServer().getPluginManager().registerEvent(
+                asyncChatEventClass,
+                this,
+                EventPriority.LOWEST,
+                (listener, event) -> {
+                    if (!asyncChatEventClass.isInstance(event)) return;
+                    try {
+                        Method getPlayerMethod = event.getClass().getMethod("getPlayer");
+                        Method messageMethod = event.getClass().getMethod("message");
+                        Player player = (Player) getPlayerMethod.invoke(event);
+                        
+                        // Paper 使用 Adventure Component, 需要提取纯文本
+                        Object component = messageMethod.invoke(event);
+                        Method plainTextMethod = Class.forName("net.kyori.adventure.text.serializer.plain.PlainComponentSerializer").getMethod("plain");
+                        Object serializer = plainTextMethod.invoke(null);
+                        Method serializeMethod = serializer.getClass().getMethod("serialize", Class.forName("net.kyori.adventure.text.Component"));
+                        String message = (String) serializeMethod.invoke(serializer, component);
+
+                        handleChatInternal(player, message, () -> {
+                            try {
+                                Method setCancelledMethod = event.getClass().getMethod("setCancelled", boolean.class);
+                                setCancelledMethod.invoke(event, true);
+                            } catch (Exception ignored) {}
+                        });
+                    } catch (Exception e) {
+                        plugin.getLogger().warning("处理 Paper 聊天事件时出错: " + e.getMessage());
+                    }
+                },
+                plugin,
+                true
+            );
+            plugin.getLogger().info("已注册 Paper 现代聊天事件监听。");
+        } catch (Exception e) {
+            plugin.getLogger().warning("无法注册 Paper 聊天监听器，将回退到标准监听器: " + e.getMessage());
+            paperChatEventExists = false;
+        }
+    }
+
+    private void handleChatInternal(Player player, String message, Runnable cancelAction) {
+        if (plugin.getCliManager().handleChat(player, message)) {
+            cancelAction.run();
         }
     }
 }

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -37,6 +37,11 @@ public class ConfigManager {
         if (!configVersion.equals(pluginVersion)) {
             plugin.getLogger().info("检测到版本更新 (" + configVersion + " -> " + pluginVersion + ")，正在更新配置...");
 
+            // 版本更新时强制更新 EULA 和 License
+            if (plugin.getEulaManager() != null) {
+                plugin.getEulaManager().forceReplaceFiles();
+            }
+
             Map<String, Object> oldValues = new HashMap<>();
             for (String key : currentConfig.getKeys(true)) {
                 if (!key.equals("version")) {

--- a/src/main/java/org/YanPl/manager/EulaManager.java
+++ b/src/main/java/org/YanPl/manager/EulaManager.java
@@ -1,0 +1,291 @@
+package org.YanPl.manager;
+
+import org.YanPl.FancyHelper;
+import org.bukkit.Bukkit;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * EULA 管理器：负责管理和实时监控 eula.txt 文件。
+ */
+public class EulaManager {
+    private final FancyHelper plugin;
+    private final File eulaFile;
+    private final File licenseFile;
+    private final List<String> eulaContent;
+    private final List<String> licenseContent;
+    private final AtomicBoolean isEulaValid = new AtomicBoolean(true);
+    private final AtomicBoolean isLicenseValid = new AtomicBoolean(true);
+    private WatchService watchService;
+    private Thread watchThread;
+    private volatile boolean running = true;
+
+    /**
+     * 初始化 EULA 管理器。
+     * 
+     * @param plugin 插件实例
+     */
+    public EulaManager(FancyHelper plugin) {
+        this.plugin = plugin;
+        File readmeDir = new File(plugin.getDataFolder(), "README");
+        if (!readmeDir.exists()) {
+            readmeDir.mkdirs();
+        }
+        this.eulaFile = new File(readmeDir, "eula.txt");
+        this.licenseFile = new File(readmeDir, "license.txt");
+        
+        this.eulaContent = Arrays.asList(
+            "=================",
+            "  FancyHelper EULA",
+            "=================",
+            "当您继续使用本插件时，即表示您已阅读并同意：",
+            "",
+            "1. 【AI 生成内容免责】",
+            "   本插件集成了第三方人工智能模型。AI 生成的所有回复均由算法",
+            "   生成，不代表开发者的观点。AI 可能会产生误导性、不准确或",
+            "   有害的信息。开发者不对 AI 生成内容的准确性、完整性或合法性",
+            "   承担任何责任。用户应自行核实相关建议。 ",
+            "",
+            "2. 【数据传输与隐私】",
+            "   为实现 AI 对话功能，您的对话内容（包括但不限于文字、上下文）",
+            "   将被加密传输至第三方服务商（如 Cloudflare, OpenAI 等）。",
+            "   请勿在对话中输入任何个人敏感信息、密码、商业秘密或违法内容。",
+            "   由于网络环境及第三方服务的不可控性，开发者不承担数据泄露风险。",
+            "",
+            "3. 【无担保声明】",
+            "   本插件按“原样 (As Is)”提供。开发者不提供任何形式的明示或",
+            "   暗示担保，包括但不限于对适销性、特定用途适用性或不侵权的担保。",
+            "   开发者不保证插件运行不中断、无错误或完全符合您的预期。",
+            "",
+            "4. 【责任限制】",
+            "   在法律允许的最大范围内，开发者不对因使用或无法使用本插件",
+            "   而产生的任何直接、间接、偶然或结果性损害（包括但不限于",
+            "   服务器崩溃、数据丢失、存档损坏、经济损失等）承担赔偿责任。",
+            "",
+            "5. 【使用合规性】",
+            "   用户承诺遵守当地法律法规。禁止利用本插件生成、传播任何",
+            "   违法、色情、暴力或侵犯他人权益的内容。若发生违规行为，",
+            "   相关法律责任由用户自行承担。",
+            "",
+            "6. 【协议变更】",
+            "   开发者保留随时修改本协议的权利。协议一经修改即刻生效。",
+            "=================================================="
+        );
+
+        this.licenseContent = Arrays.asList(
+            "本项目使用 GPL-3.0 开源。",
+            "协议文本见 https://github.com/baicaizhale/FancyHelper?tab=GPL-3.0-1-ov-file"
+        );
+
+        ensureFiles();
+        startRealtimeMonitoring();
+    }
+
+    /**
+     * 确保 EULA 和 License 文件存在且内容正确。
+     */
+    private synchronized void ensureFiles() {
+        ensureEulaFile();
+        ensureLicenseFile();
+    }
+
+    private void ensureEulaFile() {
+        try {
+            boolean needsUpdate = false;
+            if (!eulaFile.exists()) {
+                needsUpdate = true;
+            } else {
+                List<String> currentContent = Files.readAllLines(eulaFile.toPath(), StandardCharsets.UTF_8);
+                if (!eulaContent.equals(currentContent)) {
+                    needsUpdate = true;
+                }
+            }
+
+            if (needsUpdate) {
+                Files.write(eulaFile.toPath(), eulaContent, StandardCharsets.UTF_8);
+                plugin.getLogger().info("EULA 文件已创建或还原: " + eulaFile.getPath());
+            }
+            isEulaValid.set(true);
+        } catch (IOException e) {
+            plugin.getLogger().severe("无法读写 EULA 文件 (可能由于权限不足): " + e.getMessage());
+            isEulaValid.set(false);
+        }
+    }
+
+    private void ensureLicenseFile() {
+        try {
+            boolean needsUpdate = false;
+            if (!licenseFile.exists()) {
+                needsUpdate = true;
+            } else {
+                List<String> currentContent = Files.readAllLines(licenseFile.toPath(), StandardCharsets.UTF_8);
+                if (!licenseContent.equals(currentContent)) {
+                    needsUpdate = true;
+                }
+            }
+
+            if (needsUpdate) {
+                Files.write(licenseFile.toPath(), licenseContent, StandardCharsets.UTF_8);
+                plugin.getLogger().info("License 文件已创建或还原: " + licenseFile.getPath());
+            }
+            isLicenseValid.set(true);
+        } catch (IOException e) {
+            plugin.getLogger().severe("无法读写 License 文件 (可能由于权限不足): " + e.getMessage());
+            isLicenseValid.set(false);
+        }
+    }
+
+    /**
+     * 使用 Java WatchService 开始实时监控文件变动。
+     */
+    private void startRealtimeMonitoring() {
+        try {
+            this.watchService = FileSystems.getDefault().newWatchService();
+            Path path = eulaFile.getParentFile().toPath();
+            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_CREATE);
+
+            watchThread = new Thread(() -> {
+                while (running) {
+                    WatchKey key;
+                    try {
+                        key = watchService.take();
+                    } catch (InterruptedException | ClosedWatchServiceException e) {
+                        break;
+                    }
+
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        WatchEvent.Kind<?> kind = event.kind();
+                        if (kind == StandardWatchEventKinds.OVERFLOW) continue;
+
+                        Path eventPath = (Path) event.context();
+                        String fileName = eventPath.getFileName().toString();
+                        if (fileName.equals(eulaFile.getName()) || fileName.equals(licenseFile.getName())) {
+                            // 文件变动，立即还原
+                            // 稍微延迟一下以防某些编辑器锁定文件
+                            try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+                            ensureFiles();
+                        }
+                    }
+
+                    if (!key.reset()) {
+                        break;
+                    }
+                }
+            }, "FancyHelper-EULA-Monitor");
+            watchThread.setDaemon(true);
+            watchThread.start();
+            plugin.getLogger().info("EULA 实时监控已启动。");
+        } catch (IOException e) {
+            plugin.getLogger().severe("无法启动 EULA 实时监控: " + e.getMessage());
+            // 回退到每分钟检查一次的模式
+            Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::ensureEulaFile, 1200L, 1200L);
+        }
+    }
+
+    /**
+     * 检查 EULA 是否有效。
+     * 
+     * @return 如果有效则返回 true，否则返回 false。
+     */
+    public boolean isEulaValid() {
+        return isEulaValid.get();
+    }
+
+    /**
+     * 获取 EULA 文本内容。
+     * 
+     * @return EULA 文本列表
+     */
+    public List<String> getEulaContent() {
+        return eulaContent;
+    }
+
+    /**
+     * 创建一个包含 EULA 内容的虚拟书本。
+     * 
+     * @return 包含 EULA 的 ItemStack (WRITTEN_BOOK)
+     */
+    public ItemStack getEulaBook() {
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+        BookMeta meta = (BookMeta) book.getItemMeta();
+        
+        if (meta != null) {
+            meta.setTitle("FancyHelper EULA");
+            meta.setAuthor("FancyHelper");
+            
+            // 将内容分页
+            StringBuilder pageBuilder = new StringBuilder();
+            int lineCount = 0;
+            for (String line : eulaContent) {
+                pageBuilder.append(line).append("\n");
+                lineCount++;
+                
+                // 大约每 13 行一页，或者根据实际内容长度调整
+                if (lineCount >= 13) {
+                    meta.addPage(pageBuilder.toString());
+                    pageBuilder = new StringBuilder();
+                    lineCount = 0;
+                }
+            }
+            
+            // 添加最后一页
+            if (pageBuilder.length() > 0) {
+                meta.addPage(pageBuilder.toString());
+            }
+            
+            book.setItemMeta(meta);
+        }
+        
+        return book;
+    }
+
+    /**
+     * 重新加载 EULA 和 License 文件并检查。
+     */
+    public void reload() {
+        ensureFiles();
+    }
+
+    /**
+     * 强制替换 EULA 和 License 文件为当前最新内容。
+     * 通常用于版本更新时。
+     */
+    public void forceReplaceFiles() {
+        try {
+            Files.write(eulaFile.toPath(), eulaContent, StandardCharsets.UTF_8);
+            Files.write(licenseFile.toPath(), licenseContent, StandardCharsets.UTF_8);
+            plugin.getLogger().info("由于版本更新，EULA 和 License 文件已强制更新。");
+            isEulaValid.set(true);
+            isLicenseValid.set(true);
+        } catch (IOException e) {
+            plugin.getLogger().severe("强制更新文件失败: " + e.getMessage());
+            isEulaValid.set(false);
+            isLicenseValid.set(false);
+        }
+    }
+
+    /**
+     * 停止监控并释放资源。
+     */
+    public void shutdown() {
+        running = false;
+        if (watchService != null) {
+            try {
+                watchService.close();
+            } catch (IOException ignored) {}
+        }
+        if (watchThread != null) {
+            watchThread.interrupt();
+        }
+    }
+}


### PR DESCRIPTION
- 新增 EulaManager 类，负责 EULA 和 License 文件的创建、实时监控与强制还原
- 在插件启动时初始化 EulaManager，确保协议文件在配置加载前就绪
- 修改配置版本更新逻辑，在检测到版本更新时强制替换协议文件
- 扩展 CLI 命令，新增 `/cli read` 命令用于打开 EULA 虚拟书本，并支持 `/cli reload eula`
- 在用户进入 CLI 前检查 EULA 文件有效性，若文件被非法修改则拒绝访问
- 优化用户协议展示界面，提供点击阅读按钮，提升用户体验
- 改进 ChatListener 以兼容 Paper 服务器的现代聊天事件，避免重复处理
- 确保插件关闭时正确释放 EULA 监控资源