### PR TITLE
Fix

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -382,6 +382,13 @@ public class CLIManager {
     }
 
     private void checkVerificationAndExecute(Player player, String type, String args) {
+        // 检查是否被冻结
+        long freezeRemaining = plugin.getVerificationManager().getPlayerFreezeRemaining(player);
+        if (freezeRemaining > 0) {
+            player.sendMessage(ChatColor.RED + "验证已冻结，请在 " + freezeRemaining + " 秒后重试。");
+            return;
+        }
+        
         if (plugin.getConfigManager().isPlayerToolEnabled(player, type)) {
             executeFileOperation(player, type, args);
         } else {
@@ -759,6 +766,13 @@ public class CLIManager {
         if (session != null && session.getMode() == DialogueSession.Mode.YOLO) {
             String actionDesc = type.equals("ls") ? "LIST" : (type.equals("read") ? "READ" : "WRITE");
             player.sendMessage(ChatColor.GOLD + "⇒ YOLO " + actionDesc + " " + ChatColor.WHITE + args);
+            
+            // 检查是否被冻结
+            long freezeRemaining = plugin.getVerificationManager().getPlayerFreezeRemaining(player);
+            if (freezeRemaining > 0) {
+                player.sendMessage(ChatColor.RED + "验证已冻结，请在 " + freezeRemaining + " 秒后重试。");
+                return;
+            }
             
             // YOLO 模式下也需要检查权限开启，但不需要手动确认
             if (plugin.getConfigManager().isPlayerToolEnabled(player, type)) {

--- a/src/main/java/org/YanPl/manager/VerificationManager.java
+++ b/src/main/java/org/YanPl/manager/VerificationManager.java
@@ -164,4 +164,23 @@ public class VerificationManager {
     public boolean isVerifying(Player player) {
         return activeSessions.containsKey(player.getUniqueId());
     }
+    
+    /**
+     * 获取玩家验证冻结剩余时间（秒），如果未冻结则返回 0
+     * 
+     * @param player 玩家
+     * @return 剩余冻结时间（秒），0 表示未冻结
+     */
+    public long getPlayerFreezeRemaining(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (frozenPlayers.containsKey(uuid)) {
+            long unfreezeTime = frozenPlayers.get(uuid);
+            if (System.currentTimeMillis() < unfreezeTime) {
+                return (unfreezeTime - System.currentTimeMillis()) / 1000;
+            } else {
+                frozenPlayers.remove(uuid);
+            }
+        }
+        return 0;
+    }
 }


### PR DESCRIPTION
Prevent frozen players from bypassing verification by adding a freeze status check in CLIManager before executing verification operations. When a player attempts to verify while frozen, they receive a message indicating the remaining freeze duration. Also adds a utility method `getPlayerFreezeRemaining()` to VerificationManager to retrieve the remaining freeze time in seconds for any player.