### PR TITLE
fix: 将ProtocolLib依赖改为可选并添加空值检查

### DIFF
--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -44,20 +44,19 @@ public final class FancyHelper extends JavaPlugin {
         // 初始化验证管理器
         verificationManager = new VerificationManager(this);
         
-        // 强制检查 ProtocolLib 依赖
-        if (!getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
-            getLogger().severe("==================");
-            getLogger().severe("未检测到 ProtocolLib！");
-            getLogger().severe("FancyHelper 需要 ProtocolLib 才能正常工作。");
-            getLogger().severe("请前往 https://www.spigotmc.org/resources/protocollib.1997/ 下载并安装。");
-            getLogger().severe("FancyHelper将自动卸载。");
-            getLogger().severe("==================");
-            getServer().getPluginManager().disablePlugin(this);
-            return;
+        // 检查 ProtocolLib 依赖（改为可选）
+        if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+            // 初始化数据包捕获管理器
+            packetCaptureManager = new PacketCaptureManager(this);
+            getLogger().info("已检测到 ProtocolLib，启用高级功能。");
+        } else {
+            getLogger().warning("==================");
+            getLogger().warning("未检测到 ProtocolLib！");
+            getLogger().warning("FancyHelper 的部分高级功能（如命令输出捕获）将无法使用。");
+            getLogger().warning("建议前往 https://www.spigotmc.org/resources/protocollib.1997/ 下载并安装以获得最佳体验。");
+            getLogger().warning("==================");
+            packetCaptureManager = null;
         }
-        
-        // 初始化数据包捕获管理器
-        packetCaptureManager = new PacketCaptureManager(this);
         
         // 异步索引服务器命令与预设文件
         workspaceIndexer = new WorkspaceIndexer(this);

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1056,7 +1056,9 @@ public class CLIManager {
 
     private void executeCommand(Player player, String command) {
         // 开始数据包捕获
-        plugin.getPacketCaptureManager().startCapture(player);
+        if (plugin.getPacketCaptureManager() != null) {
+            plugin.getPacketCaptureManager().startCapture(player);
+        }
 
         Bukkit.getScheduler().runTask(plugin, () -> {
             StringBuilder output = new StringBuilder();
@@ -1091,7 +1093,10 @@ public class CLIManager {
             // 延迟 1 秒（20 ticks）后再处理结果，给异步任务留出时间
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 // 停止并获取数据包捕获结果
-                String packetOutput = plugin.getPacketCaptureManager().stopCapture(player);
+                String packetOutput = "";
+                if (plugin.getPacketCaptureManager() != null) {
+                    packetOutput = plugin.getPacketCaptureManager().stopCapture(player);
+                }
                 
                 // 如果 ProtocolLib 捕获到了内容，优先使用它
                 // 只有在 ProtocolLib 没捕获到且 Proxy 捕获到时，才使用 Proxy 的内容，避免重复

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: FancyHelper
 version: 2.5.4
 main: org.YanPl.FancyHelper
 api-version: '1.18'
-depend: [ProtocolLib]
+softdepend: [ProtocolLib]
 authors: [ baicaizhale , zip8919 ]
 commands:
   fancyhelper:


### PR DESCRIPTION
将plugin.yml中的depend改为softdepend，使ProtocolLib成为可选依赖。 在CLIManager中调用PacketCaptureManager前添加空值检查，防止未安装ProtocolLib时出现NullPointerException。 在插件主类中，当ProtocolLib不存在时仅输出警告而非强制禁用插件，并将packetCaptureManager设为null。