### PR TITLE
feat: 在 YOLO 模式下为风险命令添加手动确认机制

### DIFF
--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ConfigManager {
@@ -231,6 +232,10 @@ public class ConfigManager {
      */
     public int getAntiLoopMaxChainCount() {
         return config.getInt("settings.anti_loop.max_chain_count", 10);
+    }
+
+    public List<String> getYoloRiskCommands() {
+        return config.getStringList("settings.yolo_risk_commands");
     }
 
     public boolean isToolEnabled(String tool) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -44,3 +44,14 @@ settings:
     similarity_threshold: 0.95
     # 单次对话中连续调用工具的最大次数 (防止 AI 陷入逻辑循环或过度消耗)
     max_chain_count: 30
+  
+  # YOLO 模式下需要手动确认的风险命令列表（匹配前缀）
+  yolo_risk_commands:
+    - op
+    - deop
+    - stop
+    - reload
+    - restart
+    - kill
+    - nbt
+    - ban


### PR DESCRIPTION
- 在配置文件中新增 `yolo_risk_commands` 列表，用于定义需要确认的风险命令前缀
- 修改 CLIManager，在执行 YOLO 模式命令前检查是否匹配风险列表
- 若匹配，则暂停执行并发送确认按钮给玩家，等待玩家确认
- 非风险命令在 YOLO 模式下仍保持直接执行