### PR TITLE
fix: 注册display子命令以修复无法切换的问题

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -99,6 +99,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "settings":
             case "set":
             case "toggle":
+            case "display":
             case "select":
             case "exempt_anti_loop":
                 if (!(sender instanceof Player)) {
@@ -119,7 +120,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 }
                 return true;
             default:
-                sender.sendMessage(ChatColor.RED + "未知子命令。用法: /fancy [reload|status]");
+                sender.sendMessage(ChatColor.RED + "未知子命令。用法: /cli [reload|status|settings]");
                 break;
         }
 


### PR DESCRIPTION
扩展命令处理器以识别新的display子命令，同时更新未知命令的错误提示信息，使其包含所有可用的子命令选项。