### PR TITLE
fix(ai): 扩展AI思考内容标签和字段的兼容性

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -744,13 +744,13 @@ public class CLIManager {
 
         plugin.getLogger().info("[CLI] 已收到 " + player.getName() + " 的 AI 响应 (长度: " + response.length() + ")");
 
-        // 如果 response 里面还有 <thought> 标签（API 可能没拆分出来），则继续尝试提取
-        java.util.regex.Matcher thoughtMatcher = java.util.regex.Pattern.compile("(?s)<thought>(.*?)</thought>").matcher(response);
+        // 如果 response 里面还有 <thought> 或 <thinking> 标签（API 可能没拆分出来），则继续尝试提取
+        java.util.regex.Matcher thoughtMatcher = java.util.regex.Pattern.compile("(?s)<(thought|thinking)>(.*?)</\\1>").matcher(response);
         if (thoughtMatcher.find()) {
             if (thoughtContent.isEmpty()) {
-                thoughtContent = thoughtMatcher.group(1);
+                thoughtContent = thoughtMatcher.group(2);
             }
-            response = response.replaceAll("(?s)<thought>.*?</thought>", "");
+            response = response.replaceAll("(?s)<(thought|thinking)>.*?</\\1>", "");
         } else {
             // 针对某些模型可能直接在正文中用 Markdown 块或特定标记显示思考过程
             // 尝试匹配 ```thought ... ``` 块


### PR DESCRIPTION
- 在CLIManager中，正则表达式现在同时支持<thought>和<thinking>标签进行提取和清理
- 在CloudFlareAI中，为更多模型（如qwen）添加推理参数，并兼容多种思考内容字段名（reasoning_content、reasoning、thought）
- 当API响应正文为空但存在思考内容时，避免返回null，确保处理流程的健壮性