### PR TITLE
feat(notice): 添加公告定期刷新和已读标记功能

### DIFF
--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -71,13 +71,8 @@ public final class FancyHelper extends JavaPlugin {
         updateManager = new UpdateManager(this);
         updateManager.checkForUpdates();
 
-        // 初始化公告管理器并获取公告
+        // 初始化公告管理器（构造函数中会自动开始定期获取公告）
         noticeManager = new NoticeManager(this);
-        noticeManager.fetchNoticeAsync().thenAccept(noticeData -> {
-            if (noticeData != null) {
-                noticeManager.showNoticeToConsole(noticeData);
-            }
-        });
 
         CLICommand cliCommand = new CLICommand(this);
         getCommand("fancyhelper").setExecutor(cliCommand);

--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -86,7 +86,15 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage(ChatColor.RED + "你没有权限查看公告。");
                     return true;
                 }
-                handleNotice(sender);
+                if (args.length > 1 && args[1].equalsIgnoreCase("read")) {
+                    if (!(sender instanceof Player)) {
+                        sender.sendMessage(ChatColor.RED + "该子命令仅限玩家使用。");
+                        return true;
+                    }
+                    plugin.getNoticeManager().markAsRead((Player) sender);
+                } else {
+                    handleNotice(sender);
+                }
                 break;
             case "upgrade":
             case "download":
@@ -510,6 +518,10 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                     .collect(Collectors.toList());
         } else if (args.length == 2 && args[0].equalsIgnoreCase("toggle")) {
             return Arrays.asList("ls", "read", "diff").stream()
+                    .filter(s -> s.startsWith(args[1].toLowerCase()))
+                    .collect(Collectors.toList());
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("notice")) {
+            return Arrays.asList("read").stream()
                     .filter(s -> s.startsWith(args[1].toLowerCase()))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/org/YanPl/listener/ChatListener.java
+++ b/src/main/java/org/YanPl/listener/ChatListener.java
@@ -42,11 +42,22 @@ public class ChatListener implements Listener {
         }
 
         Player player = event.getPlayer();
-        plugin.getNoticeManager().fetchNoticeAsync().thenAccept(noticeData -> {
-            if (noticeData != null) {
-                plugin.getNoticeManager().showNoticeToPlayer(player, noticeData);
-            }
-        });
+        
+        // 检查玩家是否已读当前公告
+        if (plugin.getNoticeManager().hasRead(player)) {
+            return;
+        }
+
+        org.YanPl.manager.NoticeManager.NoticeData cachedNotice = plugin.getNoticeManager().getCurrentNotice();
+        if (cachedNotice != null) {
+            plugin.getNoticeManager().showNoticeToPlayer(player, cachedNotice);
+        } else {
+            plugin.getNoticeManager().fetchNoticeAsync().thenAccept(noticeData -> {
+                if (noticeData != null) {
+                    plugin.getNoticeManager().showNoticeToPlayer(player, noticeData);
+                }
+            });
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -282,8 +282,28 @@ public class ConfigManager {
      * 获取是否在玩家加入时显示公告
      * @return 是否在玩家加入时显示公告
      */
+    /**
+     * 获取公告刷新间隔（分钟）
+     * @return 刷新间隔
+     */
+    public int getNoticeRefreshInterval() {
+        return config.getInt("notice.refresh_interval", 5);
+    }
+
+    /**
+     * 获取公告是否在加入时显示
+     * @return 是否显示
+     */
     public boolean isNoticeShowOnJoin() {
         return config.getBoolean("notice.show_on_join", true);
+    }
+
+    /**
+     * 获取玩家数据配置对象
+     * @return FileConfiguration
+     */
+    public FileConfiguration getPlayerData() {
+        return playerData;
     }
 
     public boolean isToolEnabled(String tool) {
@@ -317,11 +337,11 @@ public class ConfigManager {
         savePlayerData();
     }
 
-    private void save() {
+    public void save() {
         try {
             config.save(new File(plugin.getDataFolder(), "config.yml"));
         } catch (IOException e) {
-            plugin.getLogger().warning("无法保存配置文件: " + e.getMessage());
+            plugin.getLogger().warning("无法保存配置: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/org/YanPl/manager/NoticeManager.java
+++ b/src/main/java/org/YanPl/manager/NoticeManager.java
@@ -2,7 +2,16 @@ package org.YanPl.manager;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.YanPl.FancyHelper;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.io.IOException;
 import java.net.URI;
@@ -10,6 +19,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -19,12 +30,96 @@ public class NoticeManager {
     private static final String NOTICE_URL = "https://zip8919.github.io/FancyHelper-notice/v1/notice.json";
     private final FancyHelper plugin;
     private final HttpClient httpClient;
+    private BukkitTask fetchTask;
+    private NoticeData currentNotice;
 
     public NoticeManager(FancyHelper plugin) {
         this.plugin = plugin;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+        startPeriodicFetch();
+    }
+
+    /**
+     * 启动定期拉取公告任务
+     */
+    public void startPeriodicFetch() {
+        if (fetchTask != null) {
+            fetchTask.cancel();
+        }
+
+        int interval = plugin.getConfigManager().getNoticeRefreshInterval();
+        // 转换为 tick (1分钟 = 1200 ticks)
+        long ticks = (long) interval * 1200;
+
+        fetchTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
+            fetchNoticeAsync();
+        }, 0L, ticks);
+    }
+
+    /**
+     * 检查并更新公告内容
+     *
+     * @param newData 新的公告数据
+     */
+    private void checkAndUpdateNotice(NoticeData newData) {
+        FileConfiguration playerData = plugin.getConfigManager().getPlayerData();
+        String localNoticeText = playerData.getString("notice.last_content", "");
+
+        if (!newData.text.equals(localNoticeText)) {
+            // 公告内容已更新
+            playerData.set("notice.last_content", newData.text);
+            // 清空已读列表
+            playerData.set("notice.read_players", new ArrayList<String>());
+            plugin.getConfigManager().savePlayerData();
+            plugin.getLogger().info("检测到新公告，已更新本地存储并重置已读列表。");
+            showNoticeToConsole(newData);
+        } else if (currentNotice == null) {
+            // 首次启动且内容未变，也显示一次
+            showNoticeToConsole(newData);
+        }
+    }
+
+    /**
+     * 将公告标记为已读
+     *
+     * @param player 玩家
+     */
+    public void markAsRead(Player player) {
+        FileConfiguration playerData = plugin.getConfigManager().getPlayerData();
+        List<String> readPlayers = playerData.getStringList("notice.read_players");
+        String uuid = player.getUniqueId().toString();
+
+        if (!readPlayers.contains(uuid)) {
+            readPlayers.add(uuid);
+            playerData.set("notice.read_players", readPlayers);
+            plugin.getConfigManager().savePlayerData();
+            player.sendMessage("§a[FancyHelper] 公告已标记为已读。");
+        } else {
+            player.sendMessage("§e[FancyHelper] 该公告你已经读过了。");
+        }
+    }
+
+    /**
+     * 检查玩家是否已阅读当前公告
+     *
+     * @param player 玩家
+     * @return 是否已读
+     */
+    public boolean hasRead(Player player) {
+        FileConfiguration playerData = plugin.getConfigManager().getPlayerData();
+        List<String> readPlayers = playerData.getStringList("notice.read_players");
+        return readPlayers.contains(player.getUniqueId().toString());
+    }
+
+    /**
+     * 获取当前已缓存的公告数据
+     *
+     * @return 公告数据
+     */
+    public NoticeData getCurrentNotice() {
+        return currentNotice;
     }
 
     /**
@@ -33,7 +128,12 @@ public class NoticeManager {
     public CompletableFuture<NoticeData> fetchNoticeAsync() {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                return fetchNotice();
+                NoticeData data = fetchNotice();
+                if (data != null) {
+                    this.currentNotice = data;
+                    checkAndUpdateNotice(data);
+                }
+                return data;
             } catch (IOException e) {
                 plugin.getLogger().warning("获取公告失败: " + e.getMessage());
                 return null;
@@ -103,6 +203,16 @@ public class NoticeManager {
                     player.sendMessage("§f" + line);
                 }
             }
+            
+            // 如果玩家还没读过，显示“标为已读”按钮
+            if (!hasRead(player)) {
+                TextComponent readButton = new TextComponent("§7[ §a✔ 标为已读 §7]");
+                readButton.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("§7点击将此公告标记为已读")));
+                readButton.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/fancyhelper notice read"));
+                
+                player.spigot().sendMessage(readButton);
+            }
+            
             player.sendMessage("========================================");
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -77,3 +77,5 @@ settings:
 notice:
   # 玩家加入时是否显示插件公告（需要 FancyHelper.notice 权限）
   show_on_join: true
+  # 每隔多久从服务器拉取公告（单位：分钟），默认 5 分钟
+  refresh_interval: 5


### PR DESCRIPTION
- 在配置文件中添加公告刷新间隔配置项
- 实现公告管理器定期从服务器拉取公告的功能
- 添加公告已读状态跟踪，玩家可标记公告为已读
- 优化玩家加入时的公告显示逻辑，使用缓存数据减少网络请求
- 为公告添加"标为已读"交互按钮