### PR TITLE
将所有消息前缀的颜色代码改为深青色

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -52,7 +52,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         switch (subCommand) {
             case "reload":
                 if (!sender.hasPermission("fancyhelper.reload")) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f你没有权限执行重载。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限执行重载。");
                     return true;
                 }
                 handleReload(sender, args);
@@ -63,15 +63,15 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "update":
             case "checkupdate":
                 if (!(sender.isOp() || sender.hasPermission("fancyhelper.reload"))) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f你没有权限检查更新。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限检查更新。");
                     return true;
                 }
-                sender.sendMessage("§9FancyHelper§b§r §7> §f正在检查更新...");
+                sender.sendMessage("§3FancyHelper§b§r §7> §f正在检查更新...");
                 plugin.getUpdateManager().checkForUpdates(sender instanceof Player ? (Player) sender : null);
                 break;
             case "notice":
                 if (!sender.hasPermission("fancyhelper.notice")) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f你没有权限查看公告。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限查看公告。");
                     return true;
                 }
                 if (args.length > 1 && args[1].equalsIgnoreCase("read")) {
@@ -87,7 +87,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "upgrade":
             case "download":
                 if (!sender.hasPermission("fancyhelper.reload")) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f你没有权限执行更新。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限执行更新。");
                     return true;
                 }
                 plugin.getUpdateManager().downloadAndInstall(sender instanceof Player ? (Player) sender : null, true);
@@ -118,13 +118,13 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 return true;
             case "error":
                 if (!sender.isOp()) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f该测试命令仅限管理员使用。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f该测试命令仅限管理员使用。");
                     return true;
                 }
                 if (sender instanceof Player) {
                     handleTestError((Player) sender);
                 } else {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f该测试命令仅限玩家使用。");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f该测试命令仅限玩家使用。");
                 }
                 return true;
             default:
@@ -136,7 +136,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
     }
 
     private void sendHelp(CommandSender sender) {
-        sender.sendMessage("§9FancyHelper§b§r §7> §f可用子命令:");
+        sender.sendMessage("§3FancyHelper§b§r §7> §f可用子命令:");
         sender.sendMessage(" §7- §b/cli §f: 切换进入/退出 CLI 模式");
         sender.sendMessage(" §7- §b/cli reload §f: 重新加载配置与工作区");
         sender.sendMessage(" §7- §b/cli status §f: 查看插件运行状态");
@@ -234,25 +234,25 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             plugin.getConfigManager().loadPlayerData();
             plugin.getWorkspaceIndexer().indexAll();
             plugin.getEulaManager().reload();
-            sender.sendMessage("§9FancyHelper§b§r §7> §f配置、玩家数据、工作区与 EULA 已重新加载。");
+            sender.sendMessage("§3FancyHelper§b§r §7> §f配置、玩家数据、工作区与 EULA 已重新加载。");
         } else if (args.length == 2) {
             String target = args[1].toLowerCase();
             if (target.equals("workspace")) {
                 plugin.getWorkspaceIndexer().indexAll();
-                sender.sendMessage("§9FancyHelper§b§r §7> §f工作区索引已重新加载。");
+                sender.sendMessage("§3FancyHelper§b§r §7> §f工作区索引已重新加载。");
             } else if (target.equals("config")) {
                 plugin.getConfigManager().loadConfig();
-                sender.sendMessage("§9FancyHelper§b§r §7> §f配置文件已重新加载。");
+                sender.sendMessage("§3FancyHelper§b§r §7> §f配置文件已重新加载。");
             } else if (target.equals("playerdata")) {
                 plugin.getConfigManager().loadPlayerData();
-                sender.sendMessage("§9FancyHelper§b§r §7> §f玩家数据已重新加载。");
+                sender.sendMessage("§3FancyHelper§b§r §7> §f玩家数据已重新加载。");
             } else if (target.equals("eula")) {
                 plugin.getEulaManager().reload();
-                sender.sendMessage("§9FancyHelper§b§r §7> §fEULA 文件已重新加载。");
+                sender.sendMessage("§3FancyHelper§b§r §7> §fEULA 文件已重新加载。");
             } else if (target.equals("deeply") || target.equals("deep")) {
                 handleDeepReload(sender);
             } else {
-                sender.sendMessage("§9FancyHelper§b§r §7> §f用法: /fancy reload [workspace|config|playerdata|eula|deeply]");
+                sender.sendMessage("§3FancyHelper§b§r §7> §f用法: /fancy reload [workspace|config|playerdata|eula|deeply]");
             }
         }
     }
@@ -295,9 +295,9 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             }
             pluginManager.enablePlugin(reloadPlugin);
 
-            sender.sendMessage(ChatColor.GREEN + "§9FancyHelper§b§r §7> §f正在深度重载，可能需要20s左右的时间等待响应");
+            sender.sendMessage(ChatColor.GREEN + "§3FancyHelper§b§r §7> §f正在深度重载，可能需要20s左右的时间等待响应");
         } catch (Exception e) {
-            sender.sendMessage(ChatColor.RED + "§9FancyHelper§b§r §7> §f启动重载服务时发生错误: " + e.getMessage());
+            sender.sendMessage(ChatColor.RED + "§3FancyHelper§b§r §7> §f启动重载服务时发生错误: " + e.getMessage());
             e.printStackTrace();
             plugin.getCloudErrorReport().report(e);
         }

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -202,7 +202,7 @@ public class CLIManager {
                     if (session != null && (now - session.getLastActivityTime()) > timeoutMs) {
                         Player player = Bukkit.getPlayer(uuid);
                         if (player != null) {
-                            player.sendMessage("§9FancyHelper§b§r §7> §f由于长时间未活动，已自动退出 FancyHelper。");
+                            player.sendMessage("§3FancyHelper§b§r §7> §f由于长时间未活动，已自动退出 FancyHelper。");
                             exitCLI(player);
                         } else {
                             activeCLIPayers.remove(uuid);
@@ -389,7 +389,7 @@ public class CLIManager {
 
         // 检查 EULA 文件状态
         if (!plugin.getEulaManager().isEulaValid()) {
-            player.sendMessage("§9FancyHelper§b§r §7> §f错误：EULA 文件缺失或被非法改动且无法还原，请联系管理员检查权限设置。");
+            player.sendMessage("§3FancyHelper§b§r §7> §f错误：EULA 文件缺失或被非法改动且无法还原，请联系管理员检查权限设置。");
             plugin.getLogger().warning("[CLI] 由于 EULA 文件无效，拒绝了 " + player.getName() + " 的访问。");
             return;
         }
@@ -477,7 +477,7 @@ public class CLIManager {
                 TextComponent message = new TextComponent(ChatColor.WHITE + "◆ " + timeGreeting + "，");
                 
                 TextComponent playerName = new TextComponent(player.getName());
-                playerName.setColor(net.md_5.bungee.api.ChatColor.AQUA); // 天蓝色
+                playerName.setColor(net.md_5.bungee.api.ChatColor.DARK_AQUA); // 天蓝色
                 
                 message.addExtra(playerName);
                 message.addExtra(new TextComponent(ChatColor.WHITE + "。" + randomHelp));
@@ -1385,7 +1385,7 @@ public class CLIManager {
             for (int i = 0; i < codeParts.length; i++) {
                 if (i % 2 == 1) {
                     // 代码块部分，亮蓝色显示
-                    finalMessage.addExtra(ChatColor.AQUA + codeParts[i]);
+                    finalMessage.addExtra(ChatColor.DARK_AQUA + codeParts[i]);
                 } else {
                     // 普通文本部分，进一步处理 **...** 高亮
                     String text = codeParts[i];
@@ -1394,7 +1394,7 @@ public class CLIManager {
                     for (int j = 0; j < highlightParts.length; j++) {
                         if (j % 2 == 1) {
                             // 高亮部分，亮蓝色显示
-                            finalMessage.addExtra(ChatColor.AQUA + highlightParts[j]);
+                            finalMessage.addExtra(ChatColor.DARK_AQUA + highlightParts[j]);
                         } else {
                             // 普通部分，白色显示
                             finalMessage.addExtra(ChatColor.WHITE + highlightParts[j]);
@@ -1412,7 +1412,7 @@ public class CLIManager {
     public void handleThought(Player player, String[] args) {
         DialogueSession session = sessions.get(player.getUniqueId());
         if (session == null) {
-            player.sendMessage("§9FancyHelper§b§r §7> §f当前没有活动的对话。");
+            player.sendMessage("§3FancyHelper§b§r §7> §f当前没有活动的对话。");
             return;
         }
 
@@ -1458,7 +1458,7 @@ public class CLIManager {
         }
 
         if (thought == null) {
-            player.sendMessage("§9FancyHelper§b§r §7> §f找不到对应的思考过程。");
+            player.sendMessage("§3FancyHelper§b§r §7> §f找不到对应的思考过程。");
             return;
         }
 

--- a/src/main/java/org/YanPl/manager/NoticeManager.java
+++ b/src/main/java/org/YanPl/manager/NoticeManager.java
@@ -96,9 +96,9 @@ public class NoticeManager {
             readPlayers.add(uuid);
             playerData.set("notice.read_players", readPlayers);
             plugin.getConfigManager().savePlayerData();
-            player.sendMessage("§9FancyHelper§b§r §7> §f已将公告标记为已读");
+            player.sendMessage("§3FancyHelper§b§r §7> §f已将公告标记为已读");
         } else {
-            player.sendMessage("§9FancyHelper§b§r §7> §f该公告被你标记为已读");   
+            player.sendMessage("§3FancyHelper§b§r §7> §f该公告被你标记为已读");   
         }
     }
 

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -97,25 +97,25 @@ public class UpdateManager implements Listener {
 
                     if (isNewerVersion(currentVersion, latestVersion)) {
                         hasUpdate = true;
-                        Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f检测到新版本: v" + latestVersion);
-                        Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f下载地址: " + downloadUrl);
+                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: v" + latestVersion);
+                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f下载地址: " + downloadUrl);
 
                         // 自动升级逻辑
                         if (plugin.getConfigManager().isAutoUpgrade()) {
-                            Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新...");
+                            Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新...");
                             downloadAndInstall(null, true, true);
                         } else {
-                            Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true");
+                            Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true");
                         }
 
                         if (sender != null) {
-                            sender.sendMessage("§9FancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion);
-                            sender.sendMessage("§9FancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.YELLOW + " 自动下载并更新。");
+                            sender.sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion);
+                            sender.sendMessage("§3FancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.YELLOW + " 自动下载并更新。");
                         }
                     } else {
                         hasUpdate = false;
                         // 无论 sender 是否为 null，都输出检查结果
-                        String message = "§9FancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")";
+                        String message = "§3FancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")";
                         if (sender != null) {
                             sender.sendMessage(message);
                         } else {
@@ -123,21 +123,21 @@ public class UpdateManager implements Listener {
                         }
                     }
                 } else {
-                    Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
+                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
                     if (sender != null) {
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
                     }
                 }
             } catch (IOException e) {
                 plugin.getLogger().warning("检查更新失败: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f检查更新失败: " + e.getMessage());
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新失败: " + e.getMessage());
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 plugin.getLogger().warning("检查更新被中断: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f检查更新被中断: " + e.getMessage());
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新被中断: " + e.getMessage());
                 }
             }
         });
@@ -170,12 +170,12 @@ public class UpdateManager implements Listener {
         plugin.getLogger().info("下载并安装更新被调用 - 有可用更新: " + hasUpdate + ", 下载地址: " + downloadUrl);
 
         if (!hasUpdate || downloadUrl == null) {
-            if (sender != null) sender.sendMessage("§9FancyHelper§b§r §7> §f当前没有可用的更新。");
+            if (sender != null) sender.sendMessage("§3FancyHelper§b§r §7> §f当前没有可用的更新。");
             plugin.getLogger().warning("无法下载更新：有可用更新=" + hasUpdate + ", 下载地址=" + downloadUrl);
             return;
         }
 
-        if (sender != null) sender.sendMessage("§9FancyHelper§b§r §7> §f开始下载更新...");
+        if (sender != null) sender.sendMessage("§3FancyHelper§b§r §7> §f开始下载更新...");
 
         Runnable downloadTask = () -> {
             String mirror = plugin.getConfigManager().getUpdateMirror();
@@ -201,7 +201,7 @@ public class UpdateManager implements Listener {
                 if (response.statusCode() != 200) {
                     plugin.getLogger().severe("下载失败: " + response.statusCode());
                     if (sender != null) {
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f下载失败: " + response.statusCode());
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f下载失败: " + response.statusCode());
                     }
                     throw new IOException("下载失败: " + response.statusCode());
                 }
@@ -249,26 +249,26 @@ public class UpdateManager implements Listener {
                 }
 
                 if (sender != null) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f更新下载完成！");
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载完成！");
                     if (moved) {
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
                     } else if (!moveError.isEmpty()) {
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f请在下次重启前手动处理。");
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f请在下次重启前手动处理。");
                     }
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
                     if (!autoReload) {
-                        sender.sendMessage("§9FancyHelper§b§r §7> §f请重启服务器或使用 PlugMan 重载以完成更新。");
+                        sender.sendMessage("§3FancyHelper§b§r §7> §f请重启服务器或使用 PlugMan 重载以完成更新。");
                     }
                 } else {
-                    Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f更新下载完成！");
+                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f更新下载完成！");
                     if (moved) {
-                        Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
+                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
                     } else if (!moveError.isEmpty()) {
-                        Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
-                        Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f请在下次重启前手动处理。");
+                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
+                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f请在下次重启前手动处理。");
                     }
-                    Bukkit.getConsoleSender().sendMessage("§9FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
+                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
                 }
 
                 if (autoReload) {
@@ -282,13 +282,13 @@ public class UpdateManager implements Listener {
             } catch (IOException e) {
                 plugin.getLogger().severe("更新下载失败: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f更新下载失败: " + e.getMessage());
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载失败: " + e.getMessage());
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 plugin.getLogger().severe("更新下载被中断: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§9FancyHelper§b§r §7> §f更新下载被中断: " + e.getMessage());
+                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载被中断: " + e.getMessage());
                 }
             }
         };
@@ -340,8 +340,8 @@ public class UpdateManager implements Listener {
         Player player = event.getPlayer();
         if (hasUpdate && player.isOp()) {
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                player.sendMessage("§9FancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion);
-                player.sendMessage("§9FancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。");
+                player.sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion);
+                player.sendMessage("§3FancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。");
             }, 40L); // 延迟 2 秒提示
         }
     }

--- a/src/main/java/org/YanPl/manager/VerificationManager.java
+++ b/src/main/java/org/YanPl/manager/VerificationManager.java
@@ -65,7 +65,7 @@ public class VerificationManager {
 
             if (type.equals("read") || type.equals("ls")) {
                 Files.write(verifyFile.toPath(), password.getBytes());
-                player.sendMessage("§9FancyHelper§b§r §7> §f验证文件已生成：§eplugins/FancyHelper/verify/" + verifyFile.getName());
+                player.sendMessage("§3FancyHelper§b§r §7> §f验证文件已生成：§eplugins/FancyHelper/verify/" + verifyFile.getName());
                 player.sendMessage(ChatColor.YELLOW + "请读取该文件并将其中的数字密码发送到聊天框进行验证。");
             } else {
                 player.sendMessage(ChatColor.YELLOW + "验证文件已生成：" + ChatColor.WHITE + "plugins/FancyHelper/verify/" + verifyFile.getName());


### PR DESCRIPTION
将所有 FancyHelper 消息前缀的颜色代码从 §9（深蓝）统一改为 §3（深青色）， 同时将代码高亮颜色从 ChatColor.AQUA 改为 ChatColor.DARK_AQUA，保持整体视觉风格一致