### PR TITLE
style(color): 统一使用自定义颜色工具类处理消息颜色

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import org.YanPl.FancyHelper;
 import org.YanPl.model.DialogueSession;
+import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -52,7 +53,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         switch (subCommand) {
             case "reload":
                 if (!sender.hasPermission("fancyhelper.reload")) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限执行重载。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f你没有权限执行重载。"));
                     return true;
                 }
                 handleReload(sender, args);
@@ -63,15 +64,15 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "update":
             case "checkupdate":
                 if (!(sender.isOp() || sender.hasPermission("fancyhelper.reload"))) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限检查更新。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f你没有权限检查更新。"));
                     return true;
                 }
-                sender.sendMessage("§3FancyHelper§b§r §7> §f正在检查更新...");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f正在检查更新..."));
                 plugin.getUpdateManager().checkForUpdates(sender instanceof Player ? (Player) sender : null);
                 break;
             case "notice":
                 if (!sender.hasPermission("fancyhelper.notice")) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限查看公告。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f你没有权限查看公告。"));
                     return true;
                 }
                 if (args.length > 1 && args[1].equalsIgnoreCase("read")) {
@@ -87,7 +88,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "upgrade":
             case "download":
                 if (!sender.hasPermission("fancyhelper.reload")) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f你没有权限执行更新。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f你没有权限执行更新。"));
                     return true;
                 }
                 plugin.getUpdateManager().downloadAndInstall(sender instanceof Player ? (Player) sender : null, true);
@@ -118,13 +119,13 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 return true;
             case "error":
                 if (!sender.isOp()) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f该测试命令仅限管理员使用。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f该测试命令仅限管理员使用。"));
                     return true;
                 }
                 if (sender instanceof Player) {
                     handleTestError((Player) sender);
                 } else {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f该测试命令仅限玩家使用。");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f该测试命令仅限玩家使用。"));
                 }
                 return true;
             default:
@@ -136,7 +137,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
     }
 
     private void sendHelp(CommandSender sender) {
-        sender.sendMessage("§3FancyHelper§b§r §7> §f可用子命令:");
+        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f可用子命令:"));
         sender.sendMessage(" §7- §b/cli §f: 切换进入/退出 CLI 模式");
         sender.sendMessage(" §7- §b/cli reload §f: 重新加载配置与工作区");
         sender.sendMessage(" §7- §b/cli status §f: 查看插件运行状态");
@@ -234,25 +235,25 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             plugin.getConfigManager().loadPlayerData();
             plugin.getWorkspaceIndexer().indexAll();
             plugin.getEulaManager().reload();
-            sender.sendMessage("§3FancyHelper§b§r §7> §f配置、玩家数据、工作区与 EULA 已重新加载。");
+            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f配置、玩家数据、工作区与 EULA 已重新加载。"));
         } else if (args.length == 2) {
             String target = args[1].toLowerCase();
             if (target.equals("workspace")) {
                 plugin.getWorkspaceIndexer().indexAll();
-                sender.sendMessage("§3FancyHelper§b§r §7> §f工作区索引已重新加载。");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f工作区索引已重新加载。"));
             } else if (target.equals("config")) {
                 plugin.getConfigManager().loadConfig();
-                sender.sendMessage("§3FancyHelper§b§r §7> §f配置文件已重新加载。");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f配置文件已重新加载。"));
             } else if (target.equals("playerdata")) {
                 plugin.getConfigManager().loadPlayerData();
-                sender.sendMessage("§3FancyHelper§b§r §7> §f玩家数据已重新加载。");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f玩家数据已重新加载。"));
             } else if (target.equals("eula")) {
                 plugin.getEulaManager().reload();
-                sender.sendMessage("§3FancyHelper§b§r §7> §fEULA 文件已重新加载。");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §fEULA 文件已重新加载。"));
             } else if (target.equals("deeply") || target.equals("deep")) {
                 handleDeepReload(sender);
             } else {
-                sender.sendMessage("§3FancyHelper§b§r §7> §f用法: /fancy reload [workspace|config|playerdata|eula|deeply]");
+                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f用法: /fancy reload [workspace|config|playerdata|eula|deeply]"));
             }
         }
     }
@@ -295,9 +296,9 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             }
             pluginManager.enablePlugin(reloadPlugin);
 
-            sender.sendMessage(ChatColor.GREEN + "§3FancyHelper§b§r §7> §f正在深度重载，可能需要20s左右的时间等待响应");
+            sender.sendMessage(ChatColor.GREEN + ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f正在深度重载，可能需要20s左右的时间等待响应"));
         } catch (Exception e) {
-            sender.sendMessage(ChatColor.RED + "§3FancyHelper§b§r §7> §f启动重载服务时发生错误: " + e.getMessage());
+            sender.sendMessage(ChatColor.RED + ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f启动重载服务时发生错误: " + e.getMessage()));
             e.printStackTrace();
             plugin.getCloudErrorReport().report(e);
         }

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -8,6 +8,7 @@ import org.YanPl.FancyHelper;
 import org.YanPl.api.CloudFlareAI;
 import org.YanPl.model.AIResponse;
 import org.YanPl.model.DialogueSession;
+import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -202,7 +203,7 @@ public class CLIManager {
                     if (session != null && (now - session.getLastActivityTime()) > timeoutMs) {
                         Player player = Bukkit.getPlayer(uuid);
                         if (player != null) {
-                            player.sendMessage("§3FancyHelper§b§r §7> §f由于长时间未活动，已自动退出 FancyHelper。");
+                            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f由于长时间未活动，已自动退出 FancyHelper。"));
                             exitCLI(player);
                         } else {
                             activeCLIPayers.remove(uuid);
@@ -389,7 +390,7 @@ public class CLIManager {
 
         // 检查 EULA 文件状态
         if (!plugin.getEulaManager().isEulaValid()) {
-            player.sendMessage("§3FancyHelper§b§r §7> §f错误：EULA 文件缺失或被非法改动且无法还原，请联系管理员检查权限设置。");
+            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f错误：EULA 文件缺失或被非法改动且无法还原，请联系管理员检查权限设置。"));
             plugin.getLogger().warning("[CLI] 由于 EULA 文件无效，拒绝了 " + player.getName() + " 的访问。");
             return;
         }
@@ -473,11 +474,11 @@ public class CLIManager {
                 String randomHelp = helpPhrases[new Random().nextInt(helpPhrases.length)];
 
                 // 3. 构建并发送消息
-                // 格式：◆ [问候语]，[深青色玩家名]。[随机短语]
+                // 格式：◆ [问候语]，[自定义亮蓝色玩家名]。[随机短语]
                 TextComponent message = new TextComponent(ChatColor.WHITE + "◆ " + timeGreeting + "，");
                 
                 TextComponent playerName = new TextComponent(player.getName());
-                playerName.setColor(net.md_5.bungee.api.ChatColor.DARK_AQUA); // 深青色
+                playerName.setColor(net.md_5.bungee.api.ChatColor.of("#30AEE5")); // 自定义亮蓝色
                 
                 message.addExtra(playerName);
                 message.addExtra(new TextComponent(ChatColor.WHITE + "。" + randomHelp));
@@ -1378,6 +1379,9 @@ public class CLIManager {
 
         // 处理正文内容
         if (content != null && !content.trim().isEmpty()) {
+            // 先处理自定义颜色代码 §x 和 §z
+            content = ColorUtil.translateCustomColors(content);
+            
             // 处理代码块 ```...```
             String[] codeParts = content.split("```");
             TextComponent finalMessage = new TextComponent(ChatColor.WHITE + "◆ ");
@@ -1393,8 +1397,8 @@ public class CLIManager {
                     
                     for (int j = 0; j < highlightParts.length; j++) {
                         if (j % 2 == 1) {
-                            // 高亮部分，亮蓝色显示
-                            finalMessage.addExtra(ChatColor.DARK_AQUA + highlightParts[j]);
+                            // 高亮部分，使用自定义亮蓝色 #30AEE5
+                            finalMessage.addExtra(net.md_5.bungee.api.ChatColor.of("#30AEE5") + highlightParts[j]);
                         } else {
                             // 普通部分，白色显示
                             finalMessage.addExtra(ChatColor.WHITE + highlightParts[j]);
@@ -1412,7 +1416,7 @@ public class CLIManager {
     public void handleThought(Player player, String[] args) {
         DialogueSession session = sessions.get(player.getUniqueId());
         if (session == null) {
-            player.sendMessage("§3FancyHelper§b§r §7> §f当前没有活动的对话。");
+            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前没有活动的对话。"));
             return;
         }
 
@@ -1458,7 +1462,7 @@ public class CLIManager {
         }
 
         if (thought == null) {
-            player.sendMessage("§3FancyHelper§b§r §7> §f找不到对应的思考过程。");
+            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f找不到对应的思考过程。"));
             return;
         }
 

--- a/src/main/java/org/YanPl/manager/NoticeManager.java
+++ b/src/main/java/org/YanPl/manager/NoticeManager.java
@@ -7,6 +7,7 @@ import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import org.YanPl.FancyHelper;
+import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -96,9 +97,9 @@ public class NoticeManager {
             readPlayers.add(uuid);
             playerData.set("notice.read_players", readPlayers);
             plugin.getConfigManager().savePlayerData();
-            player.sendMessage("§3FancyHelper§b§r §7> §f已将公告标记为已读");
+            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f已将公告标记为已读"));
         } else {
-            player.sendMessage("§3FancyHelper§b§r §7> §f该公告被你标记为已读");   
+            player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f该公告被你标记为已读"));   
         }
     }
 

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.YanPl.FancyHelper;
+import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -105,34 +106,51 @@ public class UpdateManager implements Listener {
 
                     if (isNewerVersion(currentVersion, latestVersion)) {
                         hasUpdate = true;
-                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: v" + latestVersion);
-                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f下载地址: " + downloadUrl);
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: v" + latestVersion));
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f下载地址: " + downloadUrl));
+
+                        // 显示 Release Overview（控制台）
+                        if (releaseOverview != null && !releaseOverview.isEmpty()) {
+                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                            for (String line : releaseOverview.split("\\r?\\n")) {
+                                String trimmedLine = line.trim();
+                                if (!trimmedLine.isEmpty()) {
+                                    trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
+                                    Bukkit.getConsoleSender().sendMessage(" §b§l> §r" + trimmedLine);
+                                }
+                            }
+                        }
 
                         // 自动升级逻辑
                         if (plugin.getConfigManager().isAutoUpgrade()) {
-                            Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新...");
+                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新..."));
                             downloadAndInstall(null, true, true);
                         } else {
-                            Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true");
+                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true"));
                         }
 
                         if (sender != null) {
-                            sender.sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion);
+                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion));
                             // 显示 Release Overview
                             if (releaseOverview != null && !releaseOverview.isEmpty()) {
-                                sender.sendMessage("§3FancyHelper§b§r §7> §f更新内容:");
-                                for (String line : releaseOverview.split("\n")) {
-                                    if (!line.trim().isEmpty()) {
-                                        sender.sendMessage(" §b§l> §r" + line);
+                                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                                // 使用正则表达式分割，支持 \n 和 \r\n
+                                for (String line : releaseOverview.split("\\r?\\n")) {
+                                    // 移除每行开头和结尾的空白字符
+                                    String trimmedLine = line.trim();
+                                    if (!trimmedLine.isEmpty()) {
+                                        // 移除 Markdown 列表符号 * - 等
+                                        trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
+                                        sender.sendMessage(" §b§l> §r" + trimmedLine);
                                     }
                                 }
                             }
-                            sender.sendMessage("§3FancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.YELLOW + " 自动下载并更新。");
+                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.YELLOW + " 自动下载并更新。"));
                         }
                     } else {
                         hasUpdate = false;
                         // 无论 sender 是否为 null，都输出检查结果
-                        String message = "§3FancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")";
+                        String message = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")");
                         if (sender != null) {
                             sender.sendMessage(message);
                         } else {
@@ -140,21 +158,21 @@ public class UpdateManager implements Listener {
                         }
                     }
                 } else {
-                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
+                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败：服务器响应异常。"));
                     if (sender != null) {
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新失败：服务器响应异常。");
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败：服务器响应异常。"));
                     }
                 }
             } catch (IOException e) {
                 plugin.getLogger().warning("检查更新失败: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新失败: " + e.getMessage());
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败: " + e.getMessage()));
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 plugin.getLogger().warning("检查更新被中断: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f检查更新被中断: " + e.getMessage());
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新被中断: " + e.getMessage()));
                 }
             }
         });
@@ -187,12 +205,12 @@ public class UpdateManager implements Listener {
         plugin.getLogger().info("下载并安装更新被调用 - 有可用更新: " + hasUpdate + ", 下载地址: " + downloadUrl);
 
         if (!hasUpdate || downloadUrl == null) {
-            if (sender != null) sender.sendMessage("§3FancyHelper§b§r §7> §f当前没有可用的更新。");
+            if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前没有可用的更新。"));
             plugin.getLogger().warning("无法下载更新：有可用更新=" + hasUpdate + ", 下载地址=" + downloadUrl);
             return;
         }
 
-        if (sender != null) sender.sendMessage("§3FancyHelper§b§r §7> §f开始下载更新...");
+        if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f开始下载更新..."));
 
         Runnable downloadTask = () -> {
             String mirror = plugin.getConfigManager().getUpdateMirror();
@@ -218,7 +236,7 @@ public class UpdateManager implements Listener {
                 if (response.statusCode() != 200) {
                     plugin.getLogger().severe("下载失败: " + response.statusCode());
                     if (sender != null) {
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f下载失败: " + response.statusCode());
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f下载失败: " + response.statusCode()));
                     }
                     throw new IOException("下载失败: " + response.statusCode());
                 }
@@ -266,26 +284,26 @@ public class UpdateManager implements Listener {
                 }
 
                 if (sender != null) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载完成！");
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载完成！"));
                     if (moved) {
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/"));
                     } else if (!moveError.isEmpty()) {
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f请在下次重启前手动处理。");
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。"));
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f请在下次重启前手动处理。"));
                     }
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f新版本已就绪: " + newJarName));
                     if (!autoReload) {
-                        sender.sendMessage("§3FancyHelper§b§r §7> §f请重启服务器或使用 PlugMan 重载以完成更新。");
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f请重启服务器或使用 PlugMan 重载以完成更新。"));
                     }
                 } else {
-                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f更新下载完成！");
+                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载完成！"));
                     if (moved) {
-                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/");
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f旧版本已成功移动至 plugins/FancyHelper/old/"));
                     } else if (!moveError.isEmpty()) {
-                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。");
-                        Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f请在下次重启前手动处理。");
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f提示：由于系统锁定，部分旧版 JAR 无法自动移动。"));
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f请在下次重启前手动处理。"));
                     }
-                    Bukkit.getConsoleSender().sendMessage("§3FancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
+                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f新版本已就绪: " + newJarName));
                 }
 
                 if (autoReload) {
@@ -299,13 +317,13 @@ public class UpdateManager implements Listener {
             } catch (IOException e) {
                 plugin.getLogger().severe("更新下载失败: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载失败: " + e.getMessage());
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载失败: " + e.getMessage()));
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 plugin.getLogger().severe("更新下载被中断: " + e.getMessage());
                 if (sender != null) {
-                    sender.sendMessage("§3FancyHelper§b§r §7> §f更新下载被中断: " + e.getMessage());
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载被中断: " + e.getMessage()));
                 }
             }
         };
@@ -410,18 +428,22 @@ public class UpdateManager implements Listener {
         Player player = event.getPlayer();
         if (hasUpdate && player.isOp()) {
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                player.sendMessage("§3FancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion);
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion));
                 // 显示 Release Overview
                 if (releaseOverview != null && !releaseOverview.isEmpty()) {
-                    player.sendMessage("§3FancyHelper§b§r §7> §f更新内容:");
-                    // 将 Overview 按行分割发送，每行前加前缀
-                    for (String line : releaseOverview.split("\n")) {
-                        if (!line.trim().isEmpty()) {
-                            player.sendMessage(" §b§l> §r" + line);
+                    player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                    // 使用正则表达式分割，支持 \n 和 \r\n
+                    for (String line : releaseOverview.split("\\r?\\n")) {
+                        // 移除每行开头和结尾的空白字符
+                        String trimmedLine = line.trim();
+                        if (!trimmedLine.isEmpty()) {
+                            // 移除 Markdown 列表符号 * - 等
+                            trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
+                            player.sendMessage(" §b§l- §r" + trimmedLine);
                         }
                     }
                 }
-                player.sendMessage("§3FancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。");
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。"));
             }, 40L); // 延迟 2 秒提示
         }
     }

--- a/src/main/java/org/YanPl/manager/VerificationManager.java
+++ b/src/main/java/org/YanPl/manager/VerificationManager.java
@@ -1,6 +1,7 @@
 package org.YanPl.manager;
 
 import org.YanPl.FancyHelper;
+import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -65,7 +66,7 @@ public class VerificationManager {
 
             if (type.equals("read") || type.equals("ls")) {
                 Files.write(verifyFile.toPath(), password.getBytes());
-                player.sendMessage("§3FancyHelper§b§r §7> §f验证文件已生成：§eplugins/FancyHelper/verify/" + verifyFile.getName());
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f验证文件已生成：§eplugins/FancyHelper/verify/" + verifyFile.getName()));
                 player.sendMessage(ChatColor.YELLOW + "请读取该文件并将其中的数字密码发送到聊天框进行验证。");
             } else {
                 player.sendMessage(ChatColor.YELLOW + "验证文件已生成：" + ChatColor.WHITE + "plugins/FancyHelper/verify/" + verifyFile.getName());

--- a/src/main/java/org/YanPl/util/ColorUtil.java
+++ b/src/main/java/org/YanPl/util/ColorUtil.java
@@ -1,0 +1,75 @@
+package org.YanPl.util;
+
+import net.md_5.bungee.api.ChatColor;
+
+/**
+ * 颜色工具类：处理自定义颜色代码转换
+ * 
+ * 支持的颜色代码：
+ * - §x -> #11A8CD (青色偏蓝)
+ * - §z -> #30AEE5 (明亮的天蓝色)
+ */
+public class ColorUtil {
+
+    // 自定义颜色代码映射
+    private static final ChatColor COLOR_X = ChatColor.of("#11A8CD");  // §x 颜色
+    private static final ChatColor COLOR_Z = ChatColor.of("#30AEE5");  // §z 颜色
+
+    /**
+     * 转换自定义颜色代码 §x 和 §z 为实际颜色
+     * 同时处理标准的 & 和 § 颜色代码
+     *
+     * @param message 包含颜色代码的消息
+     * @return 转换后的消息
+     */
+    public static String translateCustomColors(String message) {
+        if (message == null || message.isEmpty()) {
+            return message;
+        }
+
+        // 先处理标准的 & 和 § 颜色代码
+        message = ChatColor.translateAlternateColorCodes('&', message);
+
+        // 处理自定义颜色代码 §x 和 §z
+        message = message.replace("§x", COLOR_X.toString());
+        message = message.replace("§z", COLOR_Z.toString());
+
+        return message;
+    }
+
+    /**
+     * 仅转换自定义颜色代码 §x 和 §z
+     * 不处理标准的 & 和 § 颜色代码
+     *
+     * @param message 包含颜色代码的消息
+     * @return 转换后的消息
+     */
+    public static String translateCustomColorsOnly(String message) {
+        if (message == null || message.isEmpty()) {
+            return message;
+        }
+
+        message = message.replace("§x", COLOR_X.toString());
+        message = message.replace("§z", COLOR_Z.toString());
+
+        return message;
+    }
+
+    /**
+     * 获取 §x 对应的颜色值
+     *
+     * @return #11A8CD
+     */
+    public static String getColorX() {
+        return "#11A8CD";
+    }
+
+    /**
+     * 获取 §z 对应的颜色值
+     *
+     * @return #30AEE5
+     */
+    public static String getColorZ() {
+        return "#30AEE5";
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # 配置版本，请勿修改
-version: 3.5.2
+version: 3.5.3
 
 # 插件设置
 settings:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: FancyHelper
-version: 3.5.2
+version: 3.5.3
 main: org.YanPl.FancyHelper
 api-version: '1.18'
 softdepend: [ProtocolLib]


### PR DESCRIPTION
- 新增 ColorUtil 工具类用于处理自定义颜色代码
- 将所有消息前缀从 §3(深青色) 统一替换为 §z(自定义颜色)
- 玩家名称颜色从 DARK_AQUA 改为自定义亮蓝色 #30AEE5
- 改进更新日志显示格式，移除 Markdown 列表符号
- 版本号升级至 3.5.3