### PR TITLE
fix(PacketCaptureManager): 过滤玩家聊天消息避免上下文混淆

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -12,7 +12,7 @@ import org.YanPl.util.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-
+import org.bukkit.scheduler.BukkitRunnable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,8 +21,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.bukkit.scheduler.BukkitRunnable;
 
 /**
  * CLI 模式管理器，负责管理玩家的 CLI 状态和对话流

--- a/src/main/java/org/YanPl/manager/PacketCaptureManager.java
+++ b/src/main/java/org/YanPl/manager/PacketCaptureManager.java
@@ -62,8 +62,20 @@ public class PacketCaptureManager {
                         String message = extractMessage(event.getPacket());
                         if (message != null && !message.isEmpty()) {
                             // 过滤掉插件自身的提示消息，避免循环反馈或干扰 AI
-                            String stripped = ChatColor.stripColor(message);
-                            if (stripped.startsWith("⇒") || stripped.startsWith("◇") || stripped.startsWith("◆") || stripped.contains("FancyHelper")) {
+                            String stripped = ChatColor.stripColor(message).trim();
+                            if (stripped.isEmpty() || 
+                                stripped.startsWith("⇒") || 
+                                stripped.startsWith("◇") || 
+                                stripped.startsWith("◆") || 
+                                stripped.contains("FancyHelper")) {
+                                return;
+                            }
+
+                            // 关键修复：过滤掉明显的玩家聊天消息，防止多玩家环境下上下文混淆
+                            // 匹配标准聊天格式 <PlayerName> Message 或 [World] <PlayerName> Message
+                            if (stripped.matches("^<[^>]+>.*") || 
+                                stripped.matches("^\\[.*\\]\\s*<[^>]+>.*") ||
+                                stripped.matches("^\\* [^ ]+ .*")) { // /me 命令格式
                                 return;
                             }
 


### PR DESCRIPTION
修复在多人环境下，玩家聊天消息被错误捕获导致AI上下文混淆的问题。通过正则表达式匹配标准聊天格式（如<玩家名> 消息、[世界] <玩家名> 消息以及/me命令格式）并将其过滤。