### PR TITLE
refactor(util): 移除未使用的自定义颜色转换方法

### DIFF
--- a/src/main/java/org/YanPl/util/ColorUtil.java
+++ b/src/main/java/org/YanPl/util/ColorUtil.java
@@ -37,23 +37,7 @@ public class ColorUtil {
         return message;
     }
 
-    /**
-     * 仅转换自定义颜色代码 §x 和 §z
-     * 不处理标准的 & 和 § 颜色代码
-     *
-     * @param message 包含颜色代码的消息
-     * @return 转换后的消息
-     */
-    public static String translateCustomColorsOnly(String message) {
-        if (message == null || message.isEmpty()) {
-            return message;
-        }
 
-        message = message.replace("§x", COLOR_X.toString());
-        message = message.replace("§z", COLOR_Z.toString());
-
-        return message;
-    }
 
     /**
      * 获取 §x 对应的颜色值


### PR DESCRIPTION
移除 `translateCustomColorsOnly` 方法，因为该功能未被使用且与现有的 `translateCustomColors` 方法存在潜在冲突。简化 `ColorUtil` 类的结构。