### PR TITLE
feat: 添加对话会话的Token统计功能

### DIFF
--- a/src/main/java/org/YanPl/api/ResponseParser.java
+++ b/src/main/java/org/YanPl/api/ResponseParser.java
@@ -21,6 +21,24 @@ public class ResponseParser {
     public AIResponse parseResponse(JsonObject responseJson) {
         String textContent = null;
         String thoughtContent = null;
+        long promptTokens = 0;
+        long completionTokens = 0;
+
+        // 解析 Token 使用情况 (OpenAI 格式)
+        if (responseJson.has("usage") && responseJson.get("usage").isJsonObject()) {
+            JsonObject usage = responseJson.getAsJsonObject("usage");
+            promptTokens = usage.has("prompt_tokens") ? usage.get("prompt_tokens").getAsLong() : 0;
+            completionTokens = usage.has("completion_tokens") ? usage.get("completion_tokens").getAsLong() : 0;
+        }
+        // 解析 Token 使用情况 (CloudFlare result.usage 格式)
+        else if (responseJson.has("result") && responseJson.get("result").isJsonObject()) {
+            JsonObject result = responseJson.getAsJsonObject("result");
+            if (result.has("usage") && result.get("usage").isJsonObject()) {
+                JsonObject usage = result.getAsJsonObject("usage");
+                promptTokens = usage.has("prompt_tokens") ? usage.get("prompt_tokens").getAsLong() : 0;
+                completionTokens = usage.has("completion_tokens") ? usage.get("completion_tokens").getAsLong() : 0;
+            }
+        }
 
         // 1. 尝试解析 OpenAI 兼容格式 (choices 数组)
         ParsedContent openAiContent = parseOpenAiFormat(responseJson);
@@ -44,7 +62,7 @@ public class ResponseParser {
         }
 
         if (textContent != null) {
-            return new AIResponse(textContent, thoughtContent);
+            return new AIResponse(textContent, thoughtContent, promptTokens, completionTokens);
         }
         return null;
     }

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -943,6 +943,16 @@ public class CLIManager {
         DialogueSession session = sessions.get(uuid);
         if (session == null) return;
 
+        // 更新 Token 统计
+        if (aiResponse.getPromptTokens() > 0 || aiResponse.getCompletionTokens() > 0) {
+            session.addInputTokens(aiResponse.getPromptTokens());
+            session.addOutputTokens(aiResponse.getCompletionTokens());
+            plugin.getLogger().info("[CLI] Token Usage - Input: " + aiResponse.getPromptTokens() + 
+                ", Output: " + aiResponse.getCompletionTokens() + 
+                ", Total Input: " + session.getTotalInputTokens() + 
+                ", Total Output: " + session.getTotalOutputTokens());
+        }
+
         // 收到 AI 回复，立即停止计时
         recordThinkingTime(uuid);
         generationStates.put(uuid, GenerationStatus.COMPLETED);
@@ -1129,12 +1139,18 @@ public class CLIManager {
 
         // 1. 计算 System Prompt Token
         String systemPrompt = promptManager.getBaseSystemPrompt(player);
+        // System Prompt 是一条完整的消息: <|im_start|>system\n{content}<|im_end|>\n
         int systemPromptTokens = DialogueSession.calculateTokens(systemPrompt, modelName);
+        systemPromptTokens += DialogueSession.calculateTokens("system", modelName);
+        systemPromptTokens += 3; // per-message overhead
 
         // 2. 获取历史记录 Token
         int historyTokens = session.getEstimatedTokens(modelName);
+        
+        // 3. 回复引导 (Reply Primer): <|im_start|>assistant\n
+        int replyPrimerTokens = 3;
 
-        return systemPromptTokens + historyTokens;
+        return systemPromptTokens + historyTokens + replyPrimerTokens;
     }
 
     private void executeTool(Player player, String toolCall) {
@@ -1244,6 +1260,11 @@ public class CLIManager {
         if (session == null) return;
 
         session.addMessage("user", feedback);
+        
+        // 记录反馈后的 Token 估算
+        int estimatedTokens = calculateTotalEstimatedTokens(player, session);
+        plugin.getLogger().info("[CLI] Feedback added. Session size: " + session.getHistory().size() + ", Estimated Tokens for next request: " + estimatedTokens);
+
         isGenerating.put(uuid, true);
         generationStates.put(uuid, GenerationStatus.THINKING);
         generationStartTimes.put(uuid, System.currentTimeMillis());
@@ -1612,8 +1633,16 @@ public class CLIManager {
         UUID uuid = player.getUniqueId();
         DialogueSession session = sessions.get(uuid);
         
-        int tokens = session != null ? calculateTotalEstimatedTokens(player, session) : 0;
-        int thoughtTokens = session != null ? session.getThoughtTokens() : 0;
+        long totalTokens = 0;
+        long inputTokens = 0;
+        long outputTokens = 0;
+        
+        if (session != null) {
+            inputTokens = session.getTotalInputTokens();
+            outputTokens = session.getTotalOutputTokens();
+            totalTokens = inputTokens + outputTokens;
+        }
+
         long durationMs = session != null ? System.currentTimeMillis() - session.getStartTime() : 0;
         double durationSec = durationMs / 1000.0;
         
@@ -1623,7 +1652,8 @@ public class CLIManager {
         player.sendMessage(ChatColor.GRAY + "==================");
         player.sendMessage("");
         player.sendMessage(ChatColor.WHITE + "已退出 FancyHelper");
-        player.sendMessage(ChatColor.GRAY + "消耗 Token: " + (tokens + thoughtTokens) + "  | 时长: " + String.format("%.1f", durationSec) + " 秒 (思考: " + String.format("%.1f", thinkingSec) + " 秒)");
+        player.sendMessage(ChatColor.GRAY + "消耗 Token: " + totalTokens + " (In: " + inputTokens + ", Out: " + outputTokens + ")");
+        player.sendMessage(ChatColor.GRAY + "总时长: " + String.format("%.1f", durationSec) + " 秒 (思考: " + String.format("%.1f", thinkingSec) + " 秒)");
         player.sendMessage("");
         player.sendMessage(ChatColor.GRAY + "==================");
     }

--- a/src/main/java/org/YanPl/model/AIResponse.java
+++ b/src/main/java/org/YanPl/model/AIResponse.java
@@ -6,10 +6,18 @@ package org.YanPl.model;
 public class AIResponse {
     private final String content;
     private final String thought;
+    private final long promptTokens;
+    private final long completionTokens;
 
     public AIResponse(String content, String thought) {
+        this(content, thought, 0, 0);
+    }
+
+    public AIResponse(String content, String thought, long promptTokens, long completionTokens) {
         this.content = content;
         this.thought = thought;
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
     }
 
     public String getContent() {
@@ -22,5 +30,13 @@ public class AIResponse {
 
     public boolean hasThought() {
         return thought != null && !thought.isEmpty();
+    }
+
+    public long getPromptTokens() {
+        return promptTokens;
+    }
+
+    public long getCompletionTokens() {
+        return completionTokens;
     }
 }

--- a/src/main/java/org/YanPl/model/DialogueSession.java
+++ b/src/main/java/org/YanPl/model/DialogueSession.java
@@ -30,6 +30,8 @@ public class DialogueSession {
     private int toolFailureCount = 0;
     private int currentChainToolCount = 0;
     private int thoughtTokens = 0;
+    private long totalInputTokens = 0;
+    private long totalOutputTokens = 0;
     private long totalThinkingTimeMs = 0;
     private boolean antiLoopExempted = false;
     private Mode mode = Mode.NORMAL;
@@ -151,7 +153,11 @@ public class DialogueSession {
         Encoding encoding = getEncodingForModel(modelName);
         int totalTokens = 0;
         for (Message msg : history) {
+            // 每条消息的基础消耗: <|im_start|>{role}\n{content}<|im_end|>\n
+            // 约为: tokens(role) + tokens(content) + 3
+            totalTokens += encoding.countTokens(msg.getRole());
             totalTokens += encoding.countTokens(msg.getContent());
+            totalTokens += 3; 
         }
         return totalTokens;
     }
@@ -186,6 +192,22 @@ public class DialogueSession {
 
     public int getThoughtTokens() {
         return thoughtTokens;
+    }
+
+    public long getTotalInputTokens() {
+        return totalInputTokens;
+    }
+
+    public long getTotalOutputTokens() {
+        return totalOutputTokens;
+    }
+
+    public void addInputTokens(long tokens) {
+        this.totalInputTokens += tokens;
+    }
+
+    public void addOutputTokens(long tokens) {
+        this.totalOutputTokens += tokens;
     }
 
     public void addThoughtTokens(int tokens) {

--- a/src/test/java/org/YanPl/model/DialogueSessionTest.java
+++ b/src/test/java/org/YanPl/model/DialogueSessionTest.java
@@ -19,6 +19,25 @@ class DialogueSessionTest {
     }
 
     @Test
+    @DisplayName("Total Input/Output Tokens 应该正确累加")
+    void testTotalTokens() {
+        assertEquals(0, session.getTotalInputTokens());
+        assertEquals(0, session.getTotalOutputTokens());
+        
+        session.addInputTokens(100);
+        assertEquals(100, session.getTotalInputTokens());
+        
+        session.addOutputTokens(50);
+        assertEquals(50, session.getTotalOutputTokens());
+        
+        session.addInputTokens(200);
+        assertEquals(300, session.getTotalInputTokens());
+        
+        session.addOutputTokens(150);
+        assertEquals(200, session.getTotalOutputTokens());
+    }
+
+    @Test
     @DisplayName("默认构造函数应该初始化正确的默认值")
     void testDefaultConstructor() {
         assertNotNull(session.getHistory());


### PR DESCRIPTION
- 在AIResponse中添加promptTokens和completionTokens字段以记录每次响应的Token使用情况
- 在DialogueSession中增加totalInputTokens和totalOutputTokens的累计统计功能
- 修改ResponseParser以解析OpenAI和CloudFlare格式的Token使用数据
- 更新CLIManager在收到AI响应时累计Token统计并显示在退出信息中
- 改进Token估算逻辑，考虑消息格式开销和回复引导
- 添加对应的单元测试验证Token累加功能