### PR TITLE
fix: 修复文件读取和替换的安全性与性能问题

### DIFF
--- a/src/main/java/org/YanPl/manager/PromptManager.java
+++ b/src/main/java/org/YanPl/manager/PromptManager.java
@@ -163,11 +163,12 @@ public class PromptManager {
             sb.append("  #ls: <path> - List directory contents. Example: #ls: plugins/FancyHelper\n");
         }
         if (plugin.getConfigManager().isPlayerToolEnabled(player, "read")) {
-            sb.append("  #read: <path> - Read file content. Example: #read: plugins/FancyHelper/config.yml\n");
+            sb.append("  #read: <path> [start]-[end] - Read file content. Optional line range. Example: #read: plugins/FancyHelper/config.yml 1-50\n");
         }
         if (plugin.getConfigManager().isPlayerToolEnabled(player, "diff")) {
-            sb.append("  #diff: <path>|<search>|<replace> - Modify file content (find and replace).\n");
-            sb.append("    Note: Ensure precise matching. No extra spaces around | separator.\n");
+            sb.append("  #diff: <path>|<search_or_range>|<replace> - Modify file content.\n");
+            sb.append("    Mode 1 (Text Match): #diff: path|search|replace\n");
+            sb.append("    Mode 2 (Line Range): #diff: path|start-end|content (e.g. #diff: file.yml|10-20|new lines)\n");
             sb.append("    Constraint: #diff must be the last part of response. No #over after it.\n");
         }
         sb.append("\n");

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -416,7 +416,30 @@ public class ToolExecutor {
      * 执行 read 操作
      */
     private String executeReadOperation(File root, String pathArg) throws IOException {
-        File file = new File(root, pathArg);
+        String[] parts = pathArg.split("\\s+");
+        String path = parts[0];
+        int startLine = 1;
+        int endLine = -1;
+
+        if (parts.length > 1) {
+            String range = parts[1];
+            try {
+                if (range.contains("-")) {
+                    String[] rangeParts = range.split("-");
+                    if (rangeParts.length > 0 && !rangeParts[0].isEmpty()) {
+                        startLine = Integer.parseInt(rangeParts[0]);
+                    }
+                    if (rangeParts.length > 1 && !rangeParts[1].isEmpty()) {
+                        endLine = Integer.parseInt(rangeParts[1]);
+                    }
+                } else {
+                    startLine = Integer.parseInt(range);
+                    endLine = startLine; // Read single line
+                }
+            } catch (NumberFormatException ignored) {}
+        }
+
+        File file = new File(root, path);
         
         if (!isWithinRoot(root, file)) {
             return "错误: 路径超出服务器目录限制";
@@ -434,15 +457,24 @@ public class ToolExecutor {
         StringBuilder content = new StringBuilder();
         try (java.io.BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             String line;
-            int count = 0;
+            int currentLine = 1;
             int maxLines = 500;
+            int readCount = 0;
+            
             while ((line = reader.readLine()) != null) {
-                if (count >= maxLines) {
-                    content.append("\n... (内容过长，已截断显示前 " + maxLines + " 行) ...");
-                    break;
+                boolean inRange = true;
+                if (currentLine < startLine) inRange = false;
+                if (endLine != -1 && currentLine > endLine) inRange = false;
+
+                if (inRange) {
+                    if (readCount >= maxLines) {
+                        content.append("\n... (内容过长，已截断显示 " + maxLines + " 行) ...");
+                        break;
+                    }
+                    content.append(line).append("\n");
+                    readCount++;
                 }
-                content.append(line).append("\n");
-                count++;
+                currentLine++;
             }
         }
         return content.toString();
@@ -451,7 +483,6 @@ public class ToolExecutor {
     /**
      * 执行 diff 操作
      */
-    private String executeDiffOperation(File root, String pathArg) throws IOException {
         String[] diffParts = pathArg.split("\\|", 3);
         
         if (diffParts.length < 3) {
@@ -461,6 +492,21 @@ public class ToolExecutor {
         String path = diffParts[0].trim();
         String search = diffParts[1];
         String replace = diffParts[2];
+        
+        // 检查是否是行号范围模式
+        // 格式：#diff: path | 10-15 | content
+        boolean isLineMode = false;
+        int startLine = -1;
+        int endLine = -1;
+        
+        if (search.trim().matches("^\\d+-\\d+$")) {
+            try {
+                String[] range = search.trim().split("-");
+                startLine = Integer.parseInt(range[0]);
+                endLine = Integer.parseInt(range[1]);
+                isLineMode = true;
+            } catch (NumberFormatException ignored) {}
+        }
 
         File file = new File(root, path);
         
@@ -471,6 +517,45 @@ public class ToolExecutor {
             return "错误: 文件不存在";
         }
 
+        if (isLineMode) {
+            // 行号模式替换
+            List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+            if (startLine < 1 || startLine > lines.size() + 1) { // 允许追加到末尾
+                 return "错误: 起始行号无效 (文件总行数: " + lines.size() + ")";
+            }
+            if (endLine > lines.size()) {
+                 endLine = lines.size(); // 自动修正结束行号
+            }
+            if (startLine > endLine) {
+                 // 可能是插入操作？暂时不允许反向范围
+                 return "错误: 起始行号不能大于结束行号";
+            }
+            
+            List<String> newLines = new java.util.ArrayList<>();
+            
+            // 复制前面的行
+            for (int i = 0; i < startLine - 1; i++) {
+                newLines.add(lines.get(i));
+            }
+            
+            // 插入新内容
+            if (replace != null && !replace.isEmpty()) {
+                String[] replaceLines = replace.split("\n");
+                for (String rLine : replaceLines) {
+                    newLines.add(rLine);
+                }
+            }
+            
+            // 复制后面的行
+            for (int i = endLine; i < lines.size(); i++) {
+                newLines.add(lines.get(i));
+            }
+            
+            Files.write(file.toPath(), newLines, StandardCharsets.UTF_8);
+            return "成功修改文件 (行号模式): " + path + " [" + startLine + "-" + endLine + "]";
+        }
+
+        // 原有的内容匹配模式
         String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
 
         // 智能处理空格


### PR DESCRIPTION
- 将文件大小限制从100KB提升到1MB，并调整错误提示信息
- 使用缓冲流逐行读取文件，避免一次性加载大文件导致内存溢出
- 添加行数限制（500行），超限时截断显示并给出提示
- 修复文件内容替换逻辑，仅替换第一个匹配项而非全部
- 完善路径安全检查，确保文件操作限定在根目录内