### PR TITLE
refactor(ToolExecutor): 统一工具名称格式并优化工具调用解析

### DIFF
--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -66,45 +66,59 @@ public class ToolExecutor {
         String lowerToolName = toolName.toLowerCase();
 
         switch (lowerToolName) {
-            case "#over":
+            // 会话管理工具
+            case "#end":
                 cliManager.setGenerating(uuid, false, CLIManager.GenerationStatus.COMPLETED);
                 break;
             case "#exit":
                 cliManager.exitCLI(player);
                 break;
+            
+            // 执行工具
             case "#run":
                 success = handleRunTool(player, args, session);
                 break;
-            case "#ls":
+            
+            // 文件工具
+            case "#list":
                 handleFileTool(player, "ls", args, session);
                 break;
             case "#read":
                 handleFileTool(player, "read", args, session);
                 break;
-            case "#diff":
+            case "#edit":
                 handleFileTool(player, "diff", args, session);
                 break;
-            case "#getpreset":
+            case "#get_preset":
                 handleGetTool(player, args);
                 break;
+            
+            // 交互工具
             case "#choose":
                 handleChooseTool(player, args);
                 break;
+            
+            // 搜索工具
             case "#search":
                 handleSearchTool(player, args);
                 break;
+            
+            // 任务工具
             case "#todo":
                 handleTodoTool(player, args);
                 break;
+            
+            // 记忆工具
             case "#remember":
                 handleRememberTool(player, args);
                 break;
             case "#forget":
                 handleForgetKeyTool(player, args);
                 break;
-            case "#editmem":
+            case "#edit_memory":
                 handleEditmemTool(player, args);
                 break;
+            
             default:
                 player.sendMessage(ChatColor.RED + "未知工具: " + toolName);
                 String error = "#error: 未知工具 " + toolName + "。请仅使用系统提示中定义的工具。";
@@ -134,29 +148,27 @@ public class ToolExecutor {
 
     /**
      * 解析工具调用字符串
+     * 支持统一的工具调用格式：#工具名: 参数
      */
     public ToolParseResult parseToolCall(String toolCall) {
         String toolName;
         String args = "";
 
-        // 查找第一个冒号或空格的位置
+        // 查找第一个冒号的位置
         int colonIndex = toolCall.indexOf(":");
-        int spaceIndex = toolCall.indexOf(" ");
 
-        int splitIndex = -1;
-        if (colonIndex != -1 && spaceIndex != -1) {
-            splitIndex = Math.min(colonIndex, spaceIndex);
-        } else if (colonIndex != -1) {
-            splitIndex = colonIndex;
-        } else if (spaceIndex != -1) {
-            splitIndex = spaceIndex;
-        }
-
-        if (splitIndex != -1) {
-            toolName = toolCall.substring(0, splitIndex).trim();
-            args = toolCall.substring(splitIndex + 1).trim();
+        if (colonIndex != -1) {
+            toolName = toolCall.substring(0, colonIndex).trim();
+            args = toolCall.substring(colonIndex + 1).trim();
         } else {
-            toolName = toolCall.trim();
+            // 兼容旧格式，查找第一个空格
+            int spaceIndex = toolCall.indexOf(" ");
+            if (spaceIndex != -1) {
+                toolName = toolCall.substring(0, spaceIndex).trim();
+                args = toolCall.substring(spaceIndex + 1).trim();
+            } else {
+                toolName = toolCall.trim();
+            }
         }
 
         return new ToolParseResult(toolName, args);
@@ -169,7 +181,7 @@ public class ToolExecutor {
         String lowerToolName = toolName.toLowerCase();
 
         if (lowerToolName.equals("#remember") || lowerToolName.equals("#forget") ||
-            lowerToolName.equals("#editmem")) {
+            lowerToolName.equals("#edit_memory")) {
             TextComponent message = new TextComponent(ChatColor.WHITE + "⁕ Fancy 正在记住你说的话.. ");
             TextComponent manageBtn = new TextComponent("[管理记忆]");
             manageBtn.setColor(net.md_5.bungee.api.ChatColor.of(ColorUtil.getColorZ()));
@@ -177,7 +189,7 @@ public class ToolExecutor {
             manageBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "点击管理偏好记忆")));
             message.addExtra(manageBtn);
             player.spigot().sendMessage(message);
-        } else if (lowerToolName.equals("#diff")) {
+        } else if (lowerToolName.equals("#edit")) {
             String[] parts = args.split("\\|", 3);
             String path = parts.length > 0 ? parts[0].trim() : "";
             player.sendMessage(ChatColor.GRAY + "〇 正在修改文件: " + ChatColor.WHITE + path);
@@ -188,7 +200,7 @@ public class ToolExecutor {
         } else if (lowerToolName.equals("#exit")) {
             player.sendMessage(ChatColor.GRAY + "〇 Exiting...");
         } else if (!lowerToolName.equals("#search") && !lowerToolName.equals("#run") && 
-            !lowerToolName.equals("#over") && !lowerToolName.equals("#ls") && 
+            !lowerToolName.equals("#end") && !lowerToolName.equals("#list") && 
             !lowerToolName.equals("#read") && !lowerToolName.equals("#todo")) {
             player.sendMessage(ChatColor.GRAY + "〇 " + toolName);
         }
@@ -294,7 +306,7 @@ public class ToolExecutor {
 
         // YOLO 模式下直接执行
         if (session != null && session.getMode() == DialogueSession.Mode.YOLO) {
-            String actionDesc = type.equals("ls") ? "LIST" : (type.equals("read") ? "READ" : "DIFF");
+            String actionDesc = type.equals("ls") ? "LIST" : (type.equals("read") ? "READ" : "EDIT");
             player.sendMessage(ChatColor.GOLD + "⇒ YOLO " + actionDesc + " " + ChatColor.WHITE + args);
 
             // 检查是否被冻结


### PR DESCRIPTION
- 将工具名称改为下划线格式（如#edit_memory代替#editmem）
- 简化工具调用解析逻辑，优先使用冒号作为分隔符
- 添加工具分类注释以提高代码可读性
- 更新相关工具名称的引用和提示信息