### PR TITLE
feat: 优化技能工具展示并支持 #unloadskill

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -2214,7 +2214,7 @@ public class CLIManager {
         String toolCall = "";
 
         // 定义已知工具列表
-        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         boolean foundTool = false;
@@ -2359,7 +2359,7 @@ public class CLIManager {
         cleanResponse = cleanResponse.replaceAll("(?i)^思考过程:.*?\n", "");
         cleanResponse = cleanResponse.trim();
         
-        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         while (currentPos < cleanResponse.length()) {

--- a/src/main/java/org/YanPl/manager/PromptManager.java
+++ b/src/main/java/org/YanPl/manager/PromptManager.java
@@ -147,6 +147,7 @@ public class PromptManager {
         sb.append("[Query]\n");
         sb.append("  #search: <args>      - Internet search (Wiki priority). Add 'widely' to force general web search.\n");
         sb.append("  #skill: <id>         - Load Skill knowledge module. Always check Available Skills list first.\n");
+        sb.append("  #unloadskill: <id>   - Unload a loaded Skill to free context space.\n");
         sb.append("  #ask: <json>         - Present choices to player. ONE question per call.\n");
         sb.append("    Fields: question (required), header (max 12 chars), options[] (2-4, each: label + description), otherLabel (optional free-input).\n");
         sb.append("    Example: #ask: {\"question\":\"Which database?\",\"options\":[{\"label\":\"MySQL\",\"description\":\"Relational\"},{\"label\":\"MongoDB\",\"description\":\"NoSQL\"}]}\n");

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -217,8 +217,13 @@ public class ToolExecutor {
             }
         } else if (lowerToolName.equals("#exit")) {
             player.sendMessage(ChatColor.GRAY + "〇 Exiting...");
-        } else if (!lowerToolName.equals("#search") && !lowerToolName.equals("#run") && 
-            !lowerToolName.equals("#end") && !lowerToolName.equals("#list") && 
+        } else if (lowerToolName.equals("#skill")) {
+            String skillId = args.trim().toLowerCase();
+            org.YanPl.model.Skill skill = plugin.getSkillManager().getSkill(skillId);
+            String skillName = skill != null ? skill.getDisplayName() : args;
+            player.sendMessage(ChatColor.GRAY + "◌ " + ChatColor.WHITE + "Run Skill: " + skillName);
+        } else if (!lowerToolName.equals("#search") && !lowerToolName.equals("#run") &&
+            !lowerToolName.equals("#end") && !lowerToolName.equals("#list") &&
             !lowerToolName.equals("#read") && !lowerToolName.equals("#todo") &&
             !lowerToolName.equals("#getpreset") && !lowerToolName.equals("#webread")) {
             // 对 #webread 隐藏此显示，因为 #webread 会在 executeWebReader 中显示更详细的信息


### PR DESCRIPTION
## 改动

1. **美化 `#skill` 工具调用展示** — 从丑陋的 `〇 #skill` 改为 `◌ Run Skill: 技能名`（灰色圆点 + 白色技能名），让玩家更直观地看到正在加载哪个技能模块

2. **AI 自主卸载技能** — 在 Prompt 工具列表和 knownTools 中补上 `#unloadskill`，让 AI 可以在 session 中主动释放不再需要的技能，节省上下文空间

## 涉及文件

- `ToolExecutor.java` — `displayToolCall` 中为 `#skill` 新增专属展示分支
- `PromptManager.java` — Query 工具组新增 `#unloadskill` 说明
- `CLIManager.java` — knownTools 列表补上 `#unloadskill`
