### PR TITLE
fix: 流式输出空白行修复与工具展示优化

### DIFF
--- a/src/main/java/org/YanPl/api/CloudFlareAI.java
+++ b/src/main/java/org/YanPl/api/CloudFlareAI.java
@@ -216,6 +216,14 @@ public class CloudFlareAI {
     }
 
     /**
+     * 为流式输出构建可读的响应日志条目
+     * 流式没有完整的 API 响应 JSON，用累积文本模拟
+     */
+    private String buildStreamingLogResponse(String fullText) {
+        return "Streaming Response:\n" + fullText + "\n\nFinish Reason: stop\n";
+    }
+
+    /**
      * 构建消息数组（OpenAI 和 CloudFlare API 通用）
      */
     private JsonArray buildMessagesArray(DialogueSession session, String systemPrompt) {
@@ -913,6 +921,7 @@ public class CloudFlareAI {
 
         String bodyString = gson.toJson(bodyJson);
 
+
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -985,6 +994,7 @@ public class CloudFlareAI {
         bodyJson.addProperty("temperature", 0.3);
 
         String bodyString = gson.toJson(bodyJson);
+
 
         try {
             HttpRequest request = HttpRequest.newBuilder()
@@ -1066,6 +1076,7 @@ public class CloudFlareAI {
 
         String bodyString = gson.toJson(bodyJson);
 
+
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -1137,6 +1148,7 @@ public class CloudFlareAI {
         bodyJson.addProperty("temperature", 0.3);
 
         String bodyString = gson.toJson(bodyJson);
+
 
         try {
             HttpRequest request = HttpRequest.newBuilder()
@@ -1221,6 +1233,10 @@ public class CloudFlareAI {
 
         String bodyString = gson.toJson(bodyJson);
 
+        // 记录系统提示词和请求（流式模式下也需要）
+        session.logSystemPrompt(systemPrompt);
+        session.logAIRequest(bodyString);
+
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiUrl))
@@ -1237,7 +1253,9 @@ public class CloudFlareAI {
                 throw new IOException("流式请求失败: " + response.statusCode() + " - " + errorBody);
             }
 
-            return streamingHandler.processStream(response);
+            String fullText = streamingHandler.processStream(response);
+            session.logAIResponse(buildStreamingLogResponse(fullText));
+            return fullText;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("流式调用被中断: " + e.getMessage(), e);
@@ -1292,6 +1310,10 @@ public class CloudFlareAI {
 
         String bodyString = gson.toJson(bodyJson);
 
+        // 记录系统提示词和请求（流式模式下也需要）
+        session.logSystemPrompt(systemPrompt);
+        session.logAIRequest(bodyString);
+
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -1308,7 +1330,9 @@ public class CloudFlareAI {
                 throw new IOException("流式请求失败: " + response.statusCode() + " - " + errorBody);
             }
 
-            return streamingHandler.processStream(response);
+            String fullText = streamingHandler.processStream(response);
+            session.logAIResponse(buildStreamingLogResponse(fullText));
+            return fullText;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("流式调用被中断: " + e.getMessage(), e);

--- a/src/main/java/org/YanPl/api/CloudFlareAI.java
+++ b/src/main/java/org/YanPl/api/CloudFlareAI.java
@@ -105,65 +105,9 @@ public class CloudFlareAI {
      */
     private void logInteraction(DialogueSession session, String requestBody, String responseBody) {
         try {
-            // 1. 记录请求内容
-            StringBuilder requestSb = new StringBuilder();
-            try {
-                JsonElement reqEl = gson.fromJson(requestBody, JsonElement.class);
-                if (reqEl.isJsonObject()) {
-                    JsonObject reqObj = reqEl.getAsJsonObject();
-                    
-                    // 记录模型信息
-                    if (reqObj.has("model")) {
-                        requestSb.append("Model: ").append(reqObj.get("model").getAsString()).append("\n\n");
-                    }
-                    
-                    // 记录消息（只记录本次新增的消息，避免重复记录历史上下文）
-                    if (reqObj.has("messages") && reqObj.get("messages").isJsonArray()) {
-                        JsonArray messages = reqObj.get("messages").getAsJsonArray();
-                        int lastLoggedCount = session.getLastLoggedMessageCount();
-                        int newMessageCount = messages.size() - lastLoggedCount;
-                        
-                        if (newMessageCount > 0) {
-                            requestSb.append("New Messages (").append(newMessageCount).append(" items):\n");
-                            
-                            // 只记录新增的消息（从 lastLoggedCount 开始）
-                            for (int i = lastLoggedCount; i < messages.size(); i++) {
-                                JsonObject msg = messages.get(i).getAsJsonObject();
-                                if (msg.has("role") && msg.has("content")) {
-                                    String role = msg.get("role").getAsString();
-                                    String content = msg.get("content").getAsString();
-                                    
-                                    // 记录系统提示词（只记录一次）
-                                    if ("system".equals(role)) {
-                                        session.logSystemPrompt(content);
-                                    } else {
-                                        requestSb.append("\n[").append(role.toUpperCase()).append("]:\n");
-                                        requestSb.append(content).append("\n");
-                                    }
-                                }
-                            }
-                            
-                            // 更新已记录的消息数量
-                            session.setLastLoggedMessageCount(messages.size());
-                        } else {
-                            requestSb.append("No new messages (all already logged)\n");
-                        }
-                    }
-                    
-                    // 记录其他参数
-                    if (reqObj.has("max_tokens")) {
-                        requestSb.append("\nMax Tokens: ").append(reqObj.get("max_tokens").getAsInt()).append("\n");
-                    }
-                    if (reqObj.has("temperature")) {
-                        requestSb.append("Temperature: ").append(reqObj.get("temperature").getAsDouble()).append("\n");
-                    }
-                }
-            } catch (Exception e) {
-                requestSb.append("Raw Request:\n").append(requestBody).append("\n");
-            }
-            session.logAIRequest(requestSb.toString());
-            
-            // 2. 记录响应内容
+            logRequestFormatted(session, requestBody);
+
+            // 记录响应内容
             StringBuilder responseSb = new StringBuilder();
             try {
                 JsonElement respEl = gson.fromJson(responseBody, JsonElement.class);
@@ -220,7 +164,59 @@ public class CloudFlareAI {
      * 流式没有完整的 API 响应 JSON，用累积文本模拟
      */
     private String buildStreamingLogResponse(String fullText) {
-        return "Streaming Response:\n" + fullText + "\n\nFinish Reason: stop\n";
+        return fullText + "\n\n[Streaming] Finish Reason: stop\n";
+    }
+
+    /**
+     * 解析请求 JSON 并格式化写入日志（流式和非流式共用）。
+     * 只记录本次新增的消息，更新 lastLoggedMessageCount。
+     */
+    private void logRequestFormatted(DialogueSession session, String requestBody) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            JsonElement reqEl = gson.fromJson(requestBody, JsonElement.class);
+            if (reqEl.isJsonObject()) {
+                JsonObject reqObj = reqEl.getAsJsonObject();
+                if (reqObj.has("model")) {
+                    sb.append("Model: ").append(reqObj.get("model").getAsString()).append("\n\n");
+                }
+                // 支持 "messages" (OpenAI) 和 "input" (CloudFlare Responses API)
+                String msgKey = reqObj.has("messages") ? "messages" : "input";
+                if (reqObj.has(msgKey) && reqObj.get(msgKey).isJsonArray()) {
+                    JsonArray messages = reqObj.get(msgKey).getAsJsonArray();
+                    int lastLoggedCount = session.getLastLoggedMessageCount();
+                    int newMessageCount = messages.size() - lastLoggedCount;
+                    if (newMessageCount > 0) {
+                        sb.append("New Messages (").append(newMessageCount).append(" items):\n");
+                        for (int i = lastLoggedCount; i < messages.size(); i++) {
+                            JsonObject msg = messages.get(i).getAsJsonObject();
+                            if (msg.has("role") && msg.has("content")) {
+                                String role = msg.get("role").getAsString();
+                                String content = msg.get("content").getAsString();
+                                if ("system".equals(role)) {
+                                    session.logSystemPrompt(content);
+                                } else {
+                                    sb.append("\n[").append(role.toUpperCase()).append("]:\n");
+                                    sb.append(content).append("\n");
+                                }
+                            }
+                        }
+                        session.setLastLoggedMessageCount(messages.size());
+                    } else {
+                        sb.append("No new messages (all already logged)\n");
+                    }
+                }
+                if (reqObj.has("max_tokens")) {
+                    sb.append("\nMax Tokens: ").append(reqObj.get("max_tokens").getAsInt()).append("\n");
+                }
+                if (reqObj.has("temperature")) {
+                    sb.append("Temperature: ").append(reqObj.get("temperature").getAsDouble()).append("\n");
+                }
+            }
+        } catch (Exception e) {
+            sb.append("Raw Request:\n").append(requestBody).append("\n");
+        }
+        session.logAIRequest(sb.toString());
     }
 
     /**
@@ -1234,8 +1230,7 @@ public class CloudFlareAI {
         String bodyString = gson.toJson(bodyJson);
 
         // 记录系统提示词和请求（流式模式下也需要）
-        session.logSystemPrompt(systemPrompt);
-        session.logAIRequest(bodyString);
+        logRequestFormatted(session, bodyString);
 
         try {
             HttpRequest request = HttpRequest.newBuilder()
@@ -1311,8 +1306,7 @@ public class CloudFlareAI {
         String bodyString = gson.toJson(bodyJson);
 
         // 记录系统提示词和请求（流式模式下也需要）
-        session.logSystemPrompt(systemPrompt);
-        session.logAIRequest(bodyString);
+        logRequestFormatted(session, bodyString);
 
         try {
             HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -208,8 +208,10 @@ public class StreamingHandler {
                                     int hashIndex = textChunk.indexOf('#');
                                     if (hashIndex >= 0) {
                                         toolCallDetected = true;
+                                        // buffer 中可能有上一轮 flush 留下的尾部空白（如 \n\n），
+                                        // 在 # 被检测到时一并裁掉，避免正文和工具调用之间出现空行
+                                        rtrimBuffer();
                                         if (hashIndex > 0) {
-                                            // 截断 # 之前的内容，去掉尾部空白避免空行
                                             String prefix = rtrim(textChunk.substring(0, hashIndex));
                                             if (!prefix.isEmpty()) {
                                                 appendWithNewlineFlush(prefix);
@@ -544,28 +546,37 @@ public class StreamingHandler {
     }
 
     /**
-     * 发送剩余的缓冲区内容
+     * 发送剩余的缓冲区内容（最终 flush，裁掉尾部空白）
      */
     private void flushRemainingBuffer() {
         if (buffer.length() > 0 && !isCancelled.get()) {
+            rtrimBuffer();
             flushBuffer();
         }
     }
 
     /**
      * 追加文本到缓冲区，遇 \\n 自动分段 flush。
-     * 最后一个 \\n 之后的内容留在缓冲区继续累积。
+     * 最后一个 \\n 及之后的内容留在缓冲区，不立即 flush：
+     * - 若下个 chunk 是普通文本 → \\n 变为正常的行分隔
+     * - 若下个 chunk 是 # → rtrimBuffer 裁掉，避免工具调用前出现空行
      */
     private void appendWithNewlineFlush(String text) {
         if (text.isEmpty()) return;
+        // 纯空白 chunk（如 \\n\\n）全部留在 buffer，等下一个 chunk 决定命运
+        if (text.trim().isEmpty()) {
+            buffer.append(text);
+            return;
+        }
         int lastNewline = text.lastIndexOf('\n');
         if (lastNewline >= 0) {
-            buffer.append(text.substring(0, lastNewline + 1));
-            flushBuffer();
-            String remaining = text.substring(lastNewline + 1);
-            if (!remaining.isEmpty()) {
-                buffer.append(remaining);
+            // 最后一个 \\n 之前的内容立即 flush
+            if (lastNewline > 0) {
+                buffer.append(text.substring(0, lastNewline));
+                flushBuffer();
             }
+            // 最后一个 \\n 及之后的内容留在 buffer
+            buffer.append(text.substring(lastNewline));
         } else {
             buffer.append(text);
         }
@@ -580,6 +591,19 @@ public class StreamingHandler {
             end--;
         }
         return text.substring(0, end);
+    }
+
+    /**
+     * 就地裁掉 buffer 尾部的空白字符，避免 # 工具调用前残留空行
+     */
+    private void rtrimBuffer() {
+        int end = buffer.length();
+        while (end > 0 && Character.isWhitespace(buffer.charAt(end - 1))) {
+            end--;
+        }
+        if (end < buffer.length()) {
+            buffer.setLength(end);
+        }
     }
 
     /**

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -209,10 +209,14 @@ public class StreamingHandler {
                                     if (hashIndex >= 0) {
                                         toolCallDetected = true;
                                         if (hashIndex > 0) {
-                                            buffer.append(textChunk.substring(0, hashIndex));
+                                            // 截断 # 之前的内容，去掉尾部空白避免空行
+                                            String prefix = rtrim(textChunk.substring(0, hashIndex));
+                                            if (!prefix.isEmpty()) {
+                                                appendWithNewlineFlush(prefix);
+                                            }
                                         }
                                     } else {
-                                        buffer.append(textChunk);
+                                        appendWithNewlineFlush(textChunk);
                                     }
                                 }
 
@@ -505,76 +509,77 @@ public class StreamingHandler {
 
     /**
      * 如果缓冲区的视觉宽度达到阈值，则发送并清空
-     * 线程安全实现
      */
     private void flushBufferIfReady() {
         if (getVisualWidth(buffer) >= MAX_LINE_WIDTH) {
-            String text = buffer.toString();
-            // 安全检查：如果缓冲中出现 # 工具调用标记，截断并停止后续输出
-            if (!toolCallDetected) {
-                int hashIndex = text.indexOf('#');
-                if (hashIndex >= 0) {
-                    toolCallDetected = true;
-                    text = text.substring(0, hashIndex);
-                }
+            flushBuffer();
+        }
+    }
+
+    /**
+     * 强制发送缓冲区内容（忽略视觉宽度阈值）
+     */
+    private void flushBuffer() {
+        if (buffer.length() == 0) return;
+        String text = buffer.toString();
+        if (!toolCallDetected) {
+            int hashIndex = text.indexOf('#');
+            if (hashIndex >= 0) {
+                toolCallDetected = true;
+                text = text.substring(0, hashIndex);
             }
-            buffer.setLength(0);
-
-            if (onChunkCallback != null && !text.isEmpty()) {
-                try {
-                    onChunkCallback.accept(text);
-                } catch (Exception callbackError) {
-                    errorOccurred = true;
-                    logger.warning("[Stream] 数据块回调异常: " + callbackError.getMessage());
-
-                    // 调用错误回调
-                    if (onErrorCallback != null) {
-                        try {
-                            onErrorCallback.accept(callbackError);
-                        } catch (Exception errorCallbackError) {
-                            logger.warning("[Stream] 错误回调异常: " + errorCallbackError.getMessage());
-                        }
-                    }
+        }
+        buffer.setLength(0);
+        if (onChunkCallback != null && !text.isEmpty()) {
+            try {
+                onChunkCallback.accept(text);
+            } catch (Exception callbackError) {
+                errorOccurred = true;
+                logger.warning("[Stream] Flush回调异常: " + callbackError.getMessage());
+                if (onErrorCallback != null) {
+                    try { onErrorCallback.accept(callbackError); } catch (Exception e) {}
                 }
             }
         }
     }
-    
+
     /**
      * 发送剩余的缓冲区内容
-     * 线程安全实现
      */
     private void flushRemainingBuffer() {
         if (buffer.length() > 0 && !isCancelled.get()) {
-            String text = buffer.toString();
-            // 安全检查：如果缓冲中出现 # 工具调用标记，截断
-            if (!toolCallDetected) {
-                int hashIndex = text.indexOf('#');
-                if (hashIndex >= 0) {
-                    toolCallDetected = true;
-                    text = text.substring(0, hashIndex);
-                }
-            }
-            buffer.setLength(0);
-
-            if (onChunkCallback != null && !text.isEmpty()) {
-                try {
-                    onChunkCallback.accept(text);
-                } catch (Exception callbackError) {
-                    errorOccurred = true;
-                    logger.warning("[Stream] 剩余缓冲回调异常: " + callbackError.getMessage());
-
-                    // 调用错误回调
-                    if (onErrorCallback != null) {
-                        try {
-                            onErrorCallback.accept(callbackError);
-                        } catch (Exception errorCallbackError) {
-                            logger.warning("[Stream] 错误回调异常: " + errorCallbackError.getMessage());
-                        }
-                    }
-                }
-            }
+            flushBuffer();
         }
+    }
+
+    /**
+     * 追加文本到缓冲区，遇 \\n 自动分段 flush。
+     * 最后一个 \\n 之后的内容留在缓冲区继续累积。
+     */
+    private void appendWithNewlineFlush(String text) {
+        if (text.isEmpty()) return;
+        int lastNewline = text.lastIndexOf('\n');
+        if (lastNewline >= 0) {
+            buffer.append(text.substring(0, lastNewline + 1));
+            flushBuffer();
+            String remaining = text.substring(lastNewline + 1);
+            if (!remaining.isEmpty()) {
+                buffer.append(remaining);
+            }
+        } else {
+            buffer.append(text);
+        }
+    }
+
+    /**
+     * 去掉字符串尾部空白字符（空格、\\r、\\n、\\t 等）
+     */
+    private static String rtrim(String text) {
+        int end = text.length();
+        while (end > 0 && Character.isWhitespace(text.charAt(end - 1))) {
+            end--;
+        }
+        return text.substring(0, end);
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1835,15 +1835,17 @@ public class CLIManager {
                     commonPrefix++;
                 }
                 
-                String remaining = formatted.substring(commonPrefix);
+                // trim 尾部空白，避免 chunk 与 onComplete 之间 stripIncompleteFormatting
+                // 的差异导致差分出孤立的 \n 被当成空行发送给玩家
+                String remaining = formatted.substring(commonPrefix).trim();
                 lastFormatted[0] = formatted;
-                
+
                 if (!remaining.isEmpty()) {
                     String[] lines = remaining.split("\n", -1);
                     for (int i = 0; i < lines.length; i++) {
                         String line = lines[i];
                         boolean isLastLine = (i == lines.length - 1);
-                        
+
                         if (isFirstLine[0]) {
                             if (!line.isEmpty() || !isLastLine) {
                                 player.sendMessage(ChatColor.WHITE + "◆ " + line);
@@ -1856,7 +1858,7 @@ public class CLIManager {
                         }
                     }
                 }
-                
+
                 session.addMessage("assistant", response, finalThought);
 
                 if (!thoughtContent.isEmpty()) {
@@ -2756,7 +2758,7 @@ public class CLIManager {
                             while (commonPrefix < minLen && lastFormatted[0].charAt(commonPrefix) == formatted.charAt(commonPrefix)) {
                                 commonPrefix++;
                             }
-                            String remaining = formatted.substring(commonPrefix);
+                            String remaining = formatted.substring(commonPrefix).trim();
                             if (!remaining.isEmpty()) {
                                 String[] lines = remaining.split("\n", -1);
                                 for (int i = 0; i < lines.length; i++) {

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -221,7 +221,7 @@ public class ToolExecutor {
             String skillId = args.trim().toLowerCase();
             org.YanPl.model.Skill skill = plugin.getSkillManager().getSkill(skillId);
             String skillName = skill != null ? skill.getDisplayName() : args;
-            player.sendMessage(ChatColor.GRAY + "◌ " + ChatColor.WHITE + "Run Skill: " + skillName);
+            player.sendMessage(ChatColor.GRAY + "◌ Run Skill: " + skillName);
         } else if (!lowerToolName.equals("#search") && !lowerToolName.equals("#run") &&
             !lowerToolName.equals("#end") && !lowerToolName.equals("#list") &&
             !lowerToolName.equals("#read") && !lowerToolName.equals("#todo") &&
@@ -1375,7 +1375,7 @@ public class ToolExecutor {
      * 处理 #search 工具
      */
     private void handleSearchTool(Player player, String query) {
-        player.sendMessage(ChatColor.GRAY + "⨁ " + ChatColor.WHITE + "Searching: " + query);
+        player.sendMessage(ChatColor.GRAY + "⨁ Searching: " + query);
         cliManager.setGenerating(player.getUniqueId(), false, CLIManager.GenerationStatus.EXECUTING_TOOL);
 
         if (!plugin.isEnabled()) return;

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -1375,7 +1375,7 @@ public class ToolExecutor {
      * 处理 #search 工具
      */
     private void handleSearchTool(Player player, String query) {
-        player.sendMessage(ChatColor.GRAY + "〇 #search: " + query);
+        player.sendMessage(ChatColor.GRAY + "⨁ " + ChatColor.WHITE + "Searching: " + query);
         cliManager.setGenerating(player.getUniqueId(), false, CLIManager.GenerationStatus.EXECUTING_TOOL);
 
         if (!plugin.isEnabled()) return;
@@ -1415,12 +1415,6 @@ public class ToolExecutor {
     private String performWikiSearch(String query, Player player) {
         String result = fetchWikiResult(query);
         if (result.equals("未找到相关 Wiki 条目。")) {
-            // 在主线程发送消息
-            if (plugin.isEnabled()) {
-                Bukkit.getScheduler().runTask(plugin, () -> {
-                    player.sendMessage(ChatColor.GRAY + "〇 Wiki 无结果，正在尝试全网搜索...");
-                });
-            }
             if (plugin.getMetasoAPI().isAvailable()) {
                 return plugin.getMetasoAPI().search(query);
             } else if (plugin.getConfigManager().isTavilyEnabled()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # 配置版本，请勿修改
-version: 3.7.2
+version: 3.7.3
 
 # 插件设置
 settings:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: FancyHelper
-version: 3.7.2
+version: 3.7.3
 main: org.YanPl.FancyHelper
 api-version: '1.18'
 softdepend: [ ProtocolLib ]


### PR DESCRIPTION
## Summary
- 流式输出下正文与工具调用之间的空白行修复
- 流式模式下对话日志完整记录
- Skill/Search 工具调用展示美化

## Changes

### 流式输出修复 (`StreamingHandler.java`)
- `appendWithNewlineFlush` 策略变更：尾部 `\n` 留在 buffer 不立即 flush，等下一 chunk 决定命运
- `#` 检测时 `rtrimBuffer` 裁掉尾部空白，避免正文和工具调用间出现空行
- `flushRemainingBuffer` 最终 flush 前也 trim 尾部空白
- 纯空白 chunk（如 `\n\n`）直接入 buffer 不触发 flush

### 流式日志记录 (`CloudFlareAI.java`)
- 提取 `logRequestFormatted` 方法，流式/非流式共用请求格式化逻辑
- 支持 `messages`（OpenAI）和 `input`（CloudFlare Responses API）两种 key
- 正确更新 `lastLoggedMessageCount`，避免增量日志错乱

### 工具展示优化 (`ToolExecutor.java`)
- `#skill` 展示改为 `◌ Run Skill: 技能名`（全灰）
- `#search` 展示改为 `⨁ Searching: query`（全灰）
- 移除 Wiki 搜索失败时的 fallback 提示

### 其他 (`PromptManager.java`, `CLIManager.java`)
- 新增 `#unloadskill` 工具让 AI 自主卸载 skill
- `onCompleteCallback` 中 `remaining` 加 `.trim()` 防止差分残留空行

🤖 Generated with [Claude Code](https://claude.com/claude-code)