### PR TITLE
feat: 重构状态栏呼吸动画与 Token 统计逻辑

### DIFF
--- a/src/main/java/org/YanPl/api/CloudFlareAI.java
+++ b/src/main/java/org/YanPl/api/CloudFlareAI.java
@@ -348,7 +348,7 @@ public class CloudFlareAI {
 
     public AIResponse chat(DialogueSession session, String systemPrompt) throws IOException {
         // 检测是否启用 OpenAI 模式
-        if (plugin.getConfigManager().isOpenAiEnabled()) {
+        if ("openai".equalsIgnoreCase(plugin.getConfigManager().getProvider())) {
             return chatWithOpenAI(session, systemPrompt);
         }
         // 否则使用 CloudFlare Workers AI
@@ -1185,7 +1185,7 @@ public class CloudFlareAI {
      * @return 完整的响应文本
      */
     public String chatStreaming(DialogueSession session, String systemPrompt, StreamingHandler streamingHandler) throws IOException {
-        if (plugin.getConfigManager().isOpenAiEnabled()) {
+        if ("openai".equalsIgnoreCase(plugin.getConfigManager().getProvider())) {
             return chatStreamingWithOpenAI(session, systemPrompt, streamingHandler);
         }
         return chatStreamingWithCloudFlare(session, systemPrompt, streamingHandler);

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -33,6 +33,7 @@ public class StreamingHandler {
     private volatile Consumer<String> onChunkCallback;
     private volatile Consumer<String> onCompleteCallback;
     private volatile Consumer<Throwable> onErrorCallback;
+    private volatile Consumer<String> onReasoningCallback;      // 思考内容逐片回调
     private volatile Consumer<Long> onReasoningCompleteCallback;  // 思考结束回调，参数为思考耗时ms
     private volatile boolean errorOccurred = false;
     private long reasoningStartTime = -1;       // 第一个 reasoning token 的时间戳
@@ -83,6 +84,14 @@ public class StreamingHandler {
     }
 
     /**
+     * 设置思考内容逐片回调（每收到一段 reasoning_content 时触发）
+     * @param callback 回调函数，参数为思考内容文本片段
+     */
+    public void setOnReasoningCallback(Consumer<String> callback) {
+        this.onReasoningCallback = callback;
+    }
+
+    /**
      * 设置思考结束回调（当 reasoning_content 切换到 content 时触发）
      * @param callback 回调函数，参数为思考耗时毫秒
      */
@@ -117,6 +126,7 @@ public class StreamingHandler {
             onChunkCallback = null;
             onCompleteCallback = null;
             onErrorCallback = null;
+            onReasoningCallback = null;
             onReasoningCompleteCallback = null;
             buffer.setLength(0);  // 清空缓冲
             thoughtContent.setLength(0);  // 清空思考内容
@@ -354,6 +364,9 @@ public class StreamingHandler {
                                     reasoningStartTime = System.currentTimeMillis();
                                 }
                                 thoughtContent.append(rc);
+                                if (onReasoningCallback != null) {
+                                    try { onReasoningCallback.accept(rc); } catch (Exception ignored) {}
+                                }
                             }
                         }
                     }
@@ -385,6 +398,9 @@ public class StreamingHandler {
                                     reasoningStartTime = System.currentTimeMillis();
                                 }
                                 thoughtContent.append(rc);
+                                if (onReasoningCallback != null) {
+                                    try { onReasoningCallback.accept(rc); } catch (Exception ignored) {}
+                                }
                             }
                         }
                     }

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -451,18 +451,21 @@ public class StreamingHandler {
     
     /**
      * 计算文本在Minecraft聊天框中的视觉宽度
-     * 中文字符/全角字符权重为2，ASCII/半角字符权重为1
+     * 中文字符/全角字符权重为 1.7，ASCII/半角字符权重为 1.1
+     * 计数前剥离 ** 加粗标记
      * @param text 要计算的文本
      * @return 视觉宽度值
      */
-    private int getVisualWidth(CharSequence text) {
-        int width = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char c = text.charAt(i);
+    private double getVisualWidth(CharSequence text) {
+        // 剥离 ** 加粗标记，不计入视觉宽度
+        String cleaned = text.toString().replace("**", "");
+        double width = 0;
+        for (int i = 0; i < cleaned.length(); i++) {
+            char c = cleaned.charAt(i);
             if (isFullWidth(c)) {
-                width += 2;
+                width += 1.7;
             } else {
-                width += 1;
+                width += 1.1;
             }
         }
         return width;

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -53,6 +53,23 @@ public class CLIManager {
     private final Map<UUID, Boolean> isGenerating = new ConcurrentHashMap<>();
     private final Map<UUID, GenerationStatus> generationStates = new ConcurrentHashMap<>();
     private final Map<UUID, Long> generationStartTimes = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> messageReceiveTimes = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> wordStartTimes = new ConcurrentHashMap<>();
+    private final Map<UUID, String> currentThinkingWords = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> streamedOutputTokens = new ConcurrentHashMap<>();
+
+    private static final String[] THINKING_WORDS = {
+        "Coalescing", "Vibing", "Puzzling", "Computing", "Forging",
+        "Tinkering", "Unfurling", "Stewing", "Determining", "Actioning",
+        "Hatching", "Improvising"
+    };
+
+    private static final long[] BREATHING_PHASE_ENDS = { 300, 500, 600, 800, 1100 };
+    private static final String[] BREATHING_HEX = {
+        "#FF5F00", "#B34100", "#8C3200", "#B34100", "#FF5F00"
+    };
+    private static final net.md_5.bungee.api.ChatColor WORD_COLOR_BUNGEE = net.md_5.bungee.api.ChatColor.of("#FF5F00");
+    private static final net.md_5.bungee.api.ChatColor STATS_COLOR = net.md_5.bungee.api.ChatColor.GRAY;
     private final Map<UUID, String> pendingCommands = new ConcurrentHashMap<>();
     private final Map<UUID, String> interruptedToolCalls = new ConcurrentHashMap<>();
     private final Map<UUID, RetryInfo> retryInfoMap = new ConcurrentHashMap<>();
@@ -469,13 +486,58 @@ public class CLIManager {
                         case THINKING:
                             Long startTime = generationStartTimes.get(uuid);
                             if (startTime == null) {
-                                // 如果开始时间为空，可能是竞态条件导致的（状态已变更但计时器还未检测到）
-                                // 跳过显示，避免重新设置时间导致计时继续
                                 continue;
                             }
-                            long elapsed = (now - startTime) / 1000;
-                            message = ChatColor.GRAY + "- 思考中 " + elapsed + "s -";
-                            sendStatusMessage(player, message);
+
+                            long msgTime = messageReceiveTimes.getOrDefault(uuid, startTime);
+                            long elapsedFromMsg = (now - msgTime) / 1000;
+
+                            // 1. 呼吸动画 — ⁕ 颜色在 1.1s 周期内循环
+                            long animPhase = (now - startTime) % 1100;
+                            int phaseIdx = 0;
+                            for (int i = 0; i < BREATHING_PHASE_ENDS.length; i++) {
+                                if (animPhase < BREATHING_PHASE_ENDS[i]) {
+                                    phaseIdx = i;
+                                    break;
+                                }
+                            }
+                            net.md_5.bungee.api.ChatColor starColor = net.md_5.bungee.api.ChatColor.of(BREATHING_HEX[phaseIdx]);
+
+                            // 2. 随机词（每 7 秒切换）
+                            Long wordStart = wordStartTimes.get(uuid);
+                            String word = currentThinkingWords.get(uuid);
+                            if (wordStart == null || word == null || now - wordStart > 7000) {
+                                word = THINKING_WORDS[new Random().nextInt(THINKING_WORDS.length)];
+                                currentThinkingWords.put(uuid, word);
+                                wordStartTimes.put(uuid, now);
+                            }
+
+                            // 3. Token 统计（含实时流式累计）
+                            DialogueSession session = sessions.get(uuid);
+                            String tokensInfo = "";
+                            if (session != null) {
+                                long streamingTokens = streamedOutputTokens.getOrDefault(uuid, 0L);
+                                long totalTokens = session.getTotalInputTokens() + session.getTotalOutputTokens() + streamingTokens;
+                                tokensInfo = " · " + totalTokens;
+                            }
+
+                            String statsSuffix = " (" + elapsedFromMsg + "s" + tokensInfo + " tokens)";
+
+                            // ActionBar: TextComponent.setColor() 直接用 hex
+                            TextComponent comp = new TextComponent("⁕ ");
+                            comp.setColor(starColor);
+                            TextComponent wordComp = new TextComponent(word + " ");
+                            wordComp.setColor(WORD_COLOR_BUNGEE);
+                            comp.addExtra(wordComp);
+                            TextComponent statsComp = new TextComponent(statsSuffix);
+                            statsComp.setColor(STATS_COLOR);
+                            comp.addExtra(statsComp);
+
+                            // Subtitle: ChatColor.of(hex) + 字符串，其 toString() 产出 §x§R§G§B 格式，sendTitle 无 bug
+                            String subtitleMsg = starColor + "⁕ " + WORD_COLOR_BUNGEE + word
+                                + STATS_COLOR + statsSuffix;
+
+                            sendStatusMessage(player, comp, subtitleMsg);
                             break;
                         case EXECUTING_TOOL:
                             message = ChatColor.GRAY + "....";
@@ -554,10 +616,23 @@ public class CLIManager {
     private void sendStatusMessage(Player player, String message) {
         String position = plugin.getConfigManager().getPlayerDisplayPosition(player);
         if ("subtitle".equalsIgnoreCase(position)) {
-            // 为了保证 subtitle 显示，发送空内容的 title
             player.sendTitle("", message, 0, 20, 0);
         } else {
             player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(message));
+        }
+    }
+
+    /**
+     * 发送含 hex 颜色的状态消息。
+     * ActionBar 路径使用已设置好颜色的 TextComponent（避 SPIGOT-5851 §x 解析 bug），
+     * Subtitle 路径使用 §x 格式字符串（sendTitle 无此 bug）。
+     */
+    private void sendStatusMessage(Player player, TextComponent actionBarComp, String subtitleMsg) {
+        String position = plugin.getConfigManager().getPlayerDisplayPosition(player);
+        if ("subtitle".equalsIgnoreCase(position)) {
+            player.sendTitle("", subtitleMsg, 0, 20, 0);
+        } else {
+            player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, actionBarComp);
         }
     }
 
@@ -1027,6 +1102,10 @@ public class CLIManager {
         isGenerating.remove(uuid);
         generationStates.remove(uuid);
         generationStartTimes.remove(uuid);
+        messageReceiveTimes.remove(uuid);
+        wordStartTimes.remove(uuid);
+        currentThinkingWords.remove(uuid);
+        streamedOutputTokens.remove(uuid);
     }
 
     public void switchMode(Player player, DialogueSession.Mode targetMode) {
@@ -1731,13 +1810,24 @@ public class CLIManager {
             });
         });
 
+        streamingHandler.setOnReasoningCallback((reasoningChunk) -> {
+            // 异步线程直接累计 reasoning tokens
+            if (reasoningChunk == null || reasoningChunk.isEmpty()) return;
+            streamedOutputTokens.put(uuid, streamedOutputTokens.getOrDefault(uuid, 0L)
+                + DialogueSession.calculateTokens(reasoningChunk));
+        });
+
         streamingHandler.setOnChunkCallback((chunk) -> {
             if (!plugin.isEnabled() || !player.isOnline()) return;
             
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (!player.isOnline() || !isGenerating.getOrDefault(uuid, false)) return;
-                
+
                 accumulatedText.append(chunk);
+
+                // 实时累计流式输出 Token
+                streamedOutputTokens.put(uuid, streamedOutputTokens.getOrDefault(uuid, 0L)
+                    + DialogueSession.calculateTokens(chunk));
 
                 String safeText = stripIncompleteFormatting(accumulatedText.toString());
                 String formatted = convertMarkdownBoldToMinecraft(safeText);
@@ -1779,6 +1869,7 @@ public class CLIManager {
             
             fullResponseText.append(completeText);
             activeStreamingHandlers.remove(uuid);
+            streamedOutputTokens.remove(uuid);
             
             if (!plugin.isEnabled()) return;
             
@@ -1903,8 +1994,9 @@ public class CLIManager {
         streamingHandler.setOnErrorCallback((error) -> {
             if (responseHandled[0]) return;
             responseHandled[0] = true;
-            
+
             activeStreamingHandlers.remove(uuid);
+            streamedOutputTokens.remove(uuid);
             plugin.getCloudErrorReport().report(error);
             if (!plugin.isEnabled()) return;
             Bukkit.getScheduler().runTask(plugin, () -> {
@@ -1996,6 +2088,10 @@ public class CLIManager {
         isGenerating.put(uuid, true);
         generationStates.put(uuid, GenerationStatus.THINKING);
         generationStartTimes.put(uuid, System.currentTimeMillis());
+        messageReceiveTimes.put(uuid, System.currentTimeMillis());
+        wordStartTimes.put(uuid, System.currentTimeMillis());
+        currentThinkingWords.put(uuid, THINKING_WORDS[new Random().nextInt(THINKING_WORDS.length)]);
+        streamedOutputTokens.remove(uuid);
 
         TextComponent playerMsg = new TextComponent(ChatColor.GRAY + "◇ " + message);
         playerMsg.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli stop"));
@@ -2708,11 +2804,22 @@ public class CLIManager {
                     final boolean[] isFirstLine = {true};
                     final boolean[] responseHandled = {false};
 
+                    streamingHandler.setOnReasoningCallback((reasoningChunk) -> {
+                        if (reasoningChunk == null || reasoningChunk.isEmpty()) return;
+                        streamedOutputTokens.put(uuid, streamedOutputTokens.getOrDefault(uuid, 0L)
+                            + DialogueSession.calculateTokens(reasoningChunk));
+                    });
+
                     streamingHandler.setOnChunkCallback((chunk) -> {
                         if (!plugin.isEnabled() || !player.isOnline()) return;
                         Bukkit.getScheduler().runTask(plugin, () -> {
                             if (!player.isOnline() || !isGenerating.getOrDefault(uuid, false)) return;
                             accumulatedText.append(chunk);
+
+                            // 实时累计流式输出 Token
+                            streamedOutputTokens.put(uuid, streamedOutputTokens.getOrDefault(uuid, 0L)
+                                + DialogueSession.calculateTokens(chunk));
+
                             String safeText = stripIncompleteFormatting(accumulatedText.toString());
                             String formatted = convertMarkdownBoldToMinecraft(safeText);
                             formatted = ColorUtil.translateCustomColors(formatted);
@@ -2747,6 +2854,7 @@ public class CLIManager {
                         responseHandled[0] = true;
                         fullResponseText.append(completeText);
                         activeStreamingHandlers.remove(uuid);
+                        streamedOutputTokens.remove(uuid);
                         if (!plugin.isEnabled()) return;
                         Bukkit.getScheduler().runTask(plugin, () -> {
                             if (!player.isOnline()) return;
@@ -2787,6 +2895,7 @@ public class CLIManager {
                         if (responseHandled[0]) return;
                         responseHandled[0] = true;
                         activeStreamingHandlers.remove(uuid);
+                        streamedOutputTokens.remove(uuid);
                         plugin.getCloudErrorReport().report(error);
                         if (!plugin.isEnabled()) return;
                         Bukkit.getScheduler().runTask(plugin, () -> {
@@ -2805,6 +2914,7 @@ public class CLIManager {
                     if (!streamingHandler.isCancelled() && !responseHandled[0] && fullResponseText.length() == 0) {
                         responseHandled[0] = true;
                         activeStreamingHandlers.remove(uuid);
+                        streamedOutputTokens.remove(uuid);
                         String thought = streamingHandler.getThoughtContent();
                         AIResponse response = new AIResponse(completeText,
                             (thought != null && !thought.isEmpty()) ? thought : null);

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -57,6 +57,7 @@ public class CLIManager {
     private final Map<UUID, Long> wordStartTimes = new ConcurrentHashMap<>();
     private final Map<UUID, String> currentThinkingWords = new ConcurrentHashMap<>();
     private final Map<UUID, Long> streamedOutputTokens = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> roundOutputTokens = new ConcurrentHashMap<>();
 
     private static final String[] THINKING_WORDS = {
         "Coalescing", "Vibing", "Puzzling", "Computing", "Forging",
@@ -64,9 +65,12 @@ public class CLIManager {
         "Hatching", "Improvising"
     };
 
-    private static final long[] BREATHING_PHASE_ENDS = { 300, 500, 600, 800, 1100 };
+    private static final long[] BREATHING_PHASE_ENDS = { 500, 800, 1000, 1100, 1300, 1600 };
     private static final String[] BREATHING_HEX = {
-        "#FF5F00", "#B34100", "#8C3200", "#B34100", "#FF5F00"
+        "#FF7800", "#D46700", "#A15100", "#8F5200", "#A15100", "#D46700"
+    };
+    private static final String[] BREATHING_SYMBOLS = {
+        "⁕", "⁕", "⁜", "▪", "⁜", "⁕"
     };
     private static final net.md_5.bungee.api.ChatColor WORD_COLOR_BUNGEE = net.md_5.bungee.api.ChatColor.of("#FF5F00");
     private static final net.md_5.bungee.api.ChatColor STATS_COLOR = net.md_5.bungee.api.ChatColor.GRAY;
@@ -492,8 +496,8 @@ public class CLIManager {
                             long msgTime = messageReceiveTimes.getOrDefault(uuid, startTime);
                             long elapsedFromMsg = (now - msgTime) / 1000;
 
-                            // 1. 呼吸动画 — ⁕ 颜色在 1.1s 周期内循环
-                            long animPhase = (now - startTime) % 1100;
+                            // 1. 呼吸动画 — 颜色/符号在 1.6s 周期内循环
+                            long animPhase = (now - startTime) % 1600;
                             int phaseIdx = 0;
                             for (int i = 0; i < BREATHING_PHASE_ENDS.length; i++) {
                                 if (animPhase < BREATHING_PHASE_ENDS[i]) {
@@ -512,21 +516,21 @@ public class CLIManager {
                                 wordStartTimes.put(uuid, now);
                             }
 
-                            // 3. Token 统计（含实时流式累计）
+                            // 3. Token 统计（仅本轮输出，含实时流式累计）
                             DialogueSession session = sessions.get(uuid);
                             String tokensInfo = "";
                             if (session != null) {
                                 long streamingTokens = streamedOutputTokens.getOrDefault(uuid, 0L);
-                                long totalTokens = session.getTotalInputTokens() + session.getTotalOutputTokens() + streamingTokens;
-                                tokensInfo = " · " + totalTokens;
+                                long roundTokens = roundOutputTokens.getOrDefault(uuid, 0L);
+                                tokensInfo = " · " + (roundTokens + streamingTokens);
                             }
 
                             String statsSuffix = " (" + elapsedFromMsg + "s" + tokensInfo + " tokens)";
 
                             // ActionBar: TextComponent.setColor() 直接用 hex
-                            TextComponent comp = new TextComponent("⁕ ");
+                            TextComponent comp = new TextComponent(BREATHING_SYMBOLS[phaseIdx] + " ");
                             comp.setColor(starColor);
-                            TextComponent wordComp = new TextComponent(word + " ");
+                            TextComponent wordComp = new TextComponent(word + "... ");
                             wordComp.setColor(WORD_COLOR_BUNGEE);
                             comp.addExtra(wordComp);
                             TextComponent statsComp = new TextComponent(statsSuffix);
@@ -534,7 +538,7 @@ public class CLIManager {
                             comp.addExtra(statsComp);
 
                             // Subtitle: ChatColor.of(hex) + 字符串，其 toString() 产出 §x§R§G§B 格式，sendTitle 无 bug
-                            String subtitleMsg = starColor + "⁕ " + WORD_COLOR_BUNGEE + word
+                            String subtitleMsg = starColor + BREATHING_SYMBOLS[phaseIdx] + " " + WORD_COLOR_BUNGEE + word + "... "
                                 + STATS_COLOR + statsSuffix;
 
                             sendStatusMessage(player, comp, subtitleMsg);
@@ -592,7 +596,7 @@ public class CLIManager {
                     }
                 }
             }
-        }.runTaskTimer(plugin, 5L, 5L); // 提高更新频率到 0.25s，让计时更平滑
+        }.runTaskTimer(plugin, 2L, 2L); // 提高更新频率到 0.1s
     }
 
     /**
@@ -1087,6 +1091,17 @@ public class CLIManager {
         retryInfoMap.remove(uuid);
 
         recordThinkingTime(uuid);
+
+        // 退出前刷入尚未写回 session 的流式 token
+        DialogueSession exitSession = sessions.get(uuid);
+        if (exitSession != null) {
+            Long pendingStreamed = streamedOutputTokens.get(uuid);
+            if (pendingStreamed != null && pendingStreamed > 0) {
+                exitSession.addOutputTokens(pendingStreamed);
+                roundOutputTokens.merge(uuid, pendingStreamed, Long::sum);
+            }
+        }
+
         sendExitMessage(player);
         
         // 保存会话历史 - 仅在插件卸载时保存
@@ -1106,6 +1121,7 @@ public class CLIManager {
         wordStartTimes.remove(uuid);
         currentThinkingWords.remove(uuid);
         streamedOutputTokens.remove(uuid);
+        roundOutputTokens.remove(uuid);
     }
 
     public void switchMode(Player player, DialogueSession.Mode targetMode) {
@@ -1869,13 +1885,12 @@ public class CLIManager {
             
             fullResponseText.append(completeText);
             activeStreamingHandlers.remove(uuid);
-            streamedOutputTokens.remove(uuid);
-            
+
             if (!plugin.isEnabled()) return;
-            
+
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (!player.isOnline()) return;
-                
+
                 String response = completeText;
                 String thoughtContent = "";
 
@@ -1981,11 +1996,25 @@ public class CLIManager {
                 isGenerating.put(uuid, false);
                 generationStates.put(uuid, GenerationStatus.COMPLETED);
                 generationStartTimes.remove(uuid);
-                
+
                 String toolCall = extractToolCall(response);
                 if (!toolCall.isEmpty()) {
+                    // cycle 结束但有下一轮 → 当前 tokens 落 session 并清空计数器
+                    Long streamedThisCycle = streamedOutputTokens.get(uuid);
+                    if (streamedThisCycle != null && streamedThisCycle > 0) {
+                        session.addOutputTokens(streamedThisCycle);
+                        roundOutputTokens.merge(uuid, streamedThisCycle, Long::sum);
+                    }
+                    streamedOutputTokens.remove(uuid);
                     executeTool(player, toolCall);
                 } else {
+                    // 本轮输出完全结束 → 累积 token 写回 session
+                    Long streamedTotal = streamedOutputTokens.get(uuid);
+                    if (streamedTotal != null && streamedTotal > 0) {
+                        session.addOutputTokens(streamedTotal);
+                        roundOutputTokens.merge(uuid, streamedTotal, Long::sum);
+                    }
+                    streamedOutputTokens.remove(uuid);
                     checkTokenWarning(player, session);
                 }
             });
@@ -1996,10 +2025,18 @@ public class CLIManager {
             responseHandled[0] = true;
 
             activeStreamingHandlers.remove(uuid);
+            long streamedOutErr = streamedOutputTokens.getOrDefault(uuid, 0L);
             streamedOutputTokens.remove(uuid);
+            if (streamedOutErr > 0) {
+                roundOutputTokens.merge(uuid, streamedOutErr, Long::sum);
+            }
             plugin.getCloudErrorReport().report(error);
             if (!plugin.isEnabled()) return;
             Bukkit.getScheduler().runTask(plugin, () -> {
+                if (streamedOutErr > 0) {
+                    DialogueSession s = sessions.get(uuid);
+                    if (s != null) s.addOutputTokens(streamedOutErr);
+                }
                 retryInfoMap.put(uuid, new RetryInfo(session, message, true, matchedSkills));
                 player.sendMessage(ChatColor.RED + "⨀ 流式输出错误: " + error.getMessage());
                 isGenerating.put(uuid, false);
@@ -2008,7 +2045,14 @@ public class CLIManager {
             });
         });
         
-        String completeText = ai.chatStreaming(session, promptManager.getBaseSystemPrompt(player, matchedSkills), streamingHandler);
+        // 估算本轮输入的 prompt tokens 并记入 session
+        String systemPrompt = promptManager.getBaseSystemPrompt(player, matchedSkills);
+        String modelName = plugin.getConfigManager().getCloudflareModel();
+        int estimatedInput = DialogueSession.calculateTokens(systemPrompt, modelName)
+            + session.getEstimatedTokens(modelName) + 3;
+        session.addInputTokens(estimatedInput);
+
+        String completeText = ai.chatStreaming(session, systemPrompt, streamingHandler);
         
         if (!streamingHandler.isCancelled() && !responseHandled[0] && fullResponseText.length() == 0) {
             responseHandled[0] = true;
@@ -2044,7 +2088,6 @@ public class CLIManager {
             session.addMessage("assistant", finalResponse, finalThought);
             
             if (!thoughtContent.isEmpty()) {
-                String modelName = plugin.getConfigManager().getCloudflareModel();
                 int thoughtTokens = DialogueSession.calculateTokens(thoughtContent, modelName);
                 session.addThoughtTokens(thoughtTokens);
             }
@@ -2092,6 +2135,7 @@ public class CLIManager {
         wordStartTimes.put(uuid, System.currentTimeMillis());
         currentThinkingWords.put(uuid, THINKING_WORDS[new Random().nextInt(THINKING_WORDS.length)]);
         streamedOutputTokens.remove(uuid);
+        roundOutputTokens.put(uuid, 0L);
 
         TextComponent playerMsg = new TextComponent(ChatColor.GRAY + "◇ " + message);
         playerMsg.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli stop"));
@@ -2414,15 +2458,30 @@ public class CLIManager {
 
         // 处理工具调用
         if (!toolCall.isEmpty()) {
+            // cycle 结束但有下一轮 → 当前 tokens 落 session 并清空计数器
+            Long streamedThisCycle = streamedOutputTokens.get(uuid);
+            if (streamedThisCycle != null && streamedThisCycle > 0) {
+                session.addOutputTokens(streamedThisCycle);
+                roundOutputTokens.merge(uuid, streamedThisCycle, Long::sum);
+            }
+            streamedOutputTokens.remove(uuid);
             executeTool(player, toolCall);
         } else {
             // 检查响应是否被截断
             if (aiResponse.isTruncated()) {
                 // 显示截断提示
                 player.sendMessage(ChatColor.YELLOW + "⨀ 响应被截断，正在继续生成...");
-                // 自动继续生成
+                // 自动继续生成（streamedOutputTokens 不清除，延续到下一轮）
                 continueGeneration(player, session);
             } else {
+                // 本轮输出完全结束：累积的流式 token 写回 session
+                Long streamedTotal = streamedOutputTokens.get(uuid);
+                if (streamedTotal != null && streamedTotal > 0) {
+                    session.addOutputTokens(streamedTotal);
+                    roundOutputTokens.merge(uuid, streamedTotal, Long::sum);
+                }
+                streamedOutputTokens.remove(uuid);
+
                 isGenerating.put(uuid, false);
                 generationStates.put(uuid, GenerationStatus.COMPLETED);
                 checkTokenWarning(player, session);
@@ -2547,8 +2606,8 @@ public class CLIManager {
         // 设置生成状态
         isGenerating.put(uuid, true);
         generationStates.put(uuid, GenerationStatus.THINKING);
-        generationStartTimes.put(uuid, System.currentTimeMillis());
-        
+        generationStartTimes.putIfAbsent(uuid, System.currentTimeMillis());
+
         // 添加一个提示消息，让AI知道继续生成
         session.addMessage("user", "请继续生成剩余的内容");
         
@@ -2761,7 +2820,7 @@ public class CLIManager {
 
         isGenerating.put(uuid, true);
         generationStates.put(uuid, GenerationStatus.THINKING);
-        generationStartTimes.put(uuid, System.currentTimeMillis());
+        generationStartTimes.putIfAbsent(uuid, System.currentTimeMillis());
 
         // 工具返回信息不显示给玩家，仅在日志记录并触发 AI 思考
         if (plugin.getConfigManager().isDebug()) {
@@ -2854,7 +2913,7 @@ public class CLIManager {
                         responseHandled[0] = true;
                         fullResponseText.append(completeText);
                         activeStreamingHandlers.remove(uuid);
-                        streamedOutputTokens.remove(uuid);
+
                         if (!plugin.isEnabled()) return;
                         Bukkit.getScheduler().runTask(plugin, () -> {
                             if (!player.isOnline()) return;
@@ -2895,10 +2954,18 @@ public class CLIManager {
                         if (responseHandled[0]) return;
                         responseHandled[0] = true;
                         activeStreamingHandlers.remove(uuid);
+                        long streamedOutErr2 = streamedOutputTokens.getOrDefault(uuid, 0L);
                         streamedOutputTokens.remove(uuid);
+                        if (streamedOutErr2 > 0) {
+                            roundOutputTokens.merge(uuid, streamedOutErr2, Long::sum);
+                        }
                         plugin.getCloudErrorReport().report(error);
                         if (!plugin.isEnabled()) return;
                         Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (streamedOutErr2 > 0) {
+                                DialogueSession s2 = sessions.get(uuid);
+                                if (s2 != null) s2.addOutputTokens(streamedOutErr2);
+                            }
                             retryInfoMap.put(uuid, new RetryInfo(session, feedback, false, Collections.emptyList()));
                             player.sendMessage(ChatColor.RED + "⨀ 流式输出错误: " + error.getMessage());
                             isGenerating.put(uuid, false);
@@ -2908,13 +2975,24 @@ public class CLIManager {
                         });
                     });
 
+                    // 估算本轮输入的 prompt tokens 并记入 session
+                    String modelName = plugin.getConfigManager().getCloudflareModel();
+                    int estimatedInput2 = DialogueSession.calculateTokens(systemPrompt, modelName)
+                        + session.getEstimatedTokens(modelName) + 3;
+                    session.addInputTokens(estimatedInput2);
+
                     String completeText = ai.chatStreaming(session, systemPrompt, streamingHandler);
 
                     // 回退：流式未产生任何 chunk（如文本一次到达）
                     if (!streamingHandler.isCancelled() && !responseHandled[0] && fullResponseText.length() == 0) {
                         responseHandled[0] = true;
                         activeStreamingHandlers.remove(uuid);
+                        long streamedOutFallback = streamedOutputTokens.getOrDefault(uuid, 0L);
                         streamedOutputTokens.remove(uuid);
+                        if (streamedOutFallback > 0 && session != null) {
+                            session.addOutputTokens(streamedOutFallback);
+                            roundOutputTokens.merge(uuid, streamedOutFallback, Long::sum);
+                        }
                         String thought = streamingHandler.getThoughtContent();
                         AIResponse response = new AIResponse(completeText,
                             (thought != null && !thought.isEmpty()) ? thought : null);

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -2511,10 +2511,10 @@ public class CLIManager {
 
     private void checkTokenWarning(Player player, DialogueSession session) {
         int estimatedTokens = calculateTotalEstimatedTokens(player, session);
-        int maxTokens = 12800;
+        int maxTokens = plugin.getConfigManager().getContextWindowLimit();
         int remaining = maxTokens - estimatedTokens;
 
-        if (remaining < plugin.getConfigManager().getTokenWarningThreshold()) {
+        if (remaining < plugin.getConfigManager().getContextWindowWarningThreshold()) {
             player.sendMessage(ChatColor.YELLOW + "⨀ 剩余上下文长度不足 ，Fancy 可能会遗忘较早的对话内容来保证对话继续。");
         }
     }

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -110,7 +110,14 @@ public class ConfigManager {
                     newConfig.set(entry.getKey(), entry.getValue());
                 }
             }
-            
+
+            // 迁移旧版 openai.enabled 到新版 provider 字段
+            if (oldValues.containsKey("openai.enabled")) {
+                boolean openaiWasEnabled = Boolean.parseBoolean(String.valueOf(oldValues.get("openai.enabled")));
+                newConfig.set("provider", openaiWasEnabled ? "openai" : "cloudflare");
+                plugin.getLogger().info("已迁移旧配置 openai.enabled=" + openaiWasEnabled + " 到 provider=" + (openaiWasEnabled ? "openai" : "cloudflare"));
+            }
+
             try {
                 newConfig.save(configFile);
                 plugin.getLogger().info("配置文件更新完成！");
@@ -220,11 +227,11 @@ public class ConfigManager {
     }
 
     /**
-     * 获取是否启用 OpenAI 模式
-     * @return 是否启用 OpenAI 模式
+     * 获取 AI 提供商
+     * @return AI 提供商名称 (cloudflare 或 openai)
      */
-    public boolean isOpenAiEnabled() {
-        return config.getBoolean("openai.enabled", false);
+    public String getProvider() {
+        return config.getString("provider", "cloudflare");
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -118,6 +118,13 @@ public class ConfigManager {
                 plugin.getLogger().info("已迁移旧配置 openai.enabled=" + openaiWasEnabled + " 到 provider=" + (openaiWasEnabled ? "openai" : "cloudflare"));
             }
 
+            // 迁移旧版 token_warning_threshold 到 context_window_warning_threshold
+            if (oldValues.containsKey("settings.token_warning_threshold")) {
+                Object oldVal = oldValues.get("settings.token_warning_threshold");
+                newConfig.set("settings.context_window_warning_threshold", oldVal);
+                plugin.getLogger().info("已迁移旧配置 settings.token_warning_threshold=" + oldVal + " 到 settings.context_window_warning_threshold=" + oldVal);
+            }
+
             try {
                 newConfig.save(configFile);
                 plugin.getLogger().info("配置文件更新完成！");
@@ -270,8 +277,16 @@ public class ConfigManager {
         return config.getInt("settings.api_timeout_seconds", 120);
     }
 
-    public int getTokenWarningThreshold() {
-        return config.getInt("settings.token_warning_threshold", 500);
+    public int getContextWindowWarningThreshold() {
+        return config.getInt("settings.context_window_warning_threshold", 500);
+    }
+
+    /**
+     * 获取上下文窗口大小上限
+     * @return 上下文窗口大小上限（token数）
+     */
+    public int getContextWindowLimit() {
+        return config.getInt("settings.context_window_limit", 12800);
     }
 
     public boolean isAutoReportEnabled() {

--- a/src/main/java/org/YanPl/model/DialogueSession.java
+++ b/src/main/java/org/YanPl/model/DialogueSession.java
@@ -42,8 +42,8 @@ public class DialogueSession {
     private int toolFailureCount = 0;
     private int currentChainToolCount = 0;
     private int thoughtTokens = 0;
-    private long totalInputTokens = 0;
-    private long totalOutputTokens = 0;
+    private volatile long totalInputTokens = 0;
+    private volatile long totalOutputTokens = 0;
     private long totalThinkingTimeMs = 0;
     private boolean antiLoopExempted = false;
     private Mode mode = Mode.NORMAL;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,9 @@
 # 配置版本，请勿修改
 version: 3.7.3
 
+# AI 提供商选择: cloudflare 或 openai（默认 cloudflare）
+provider: cloudflare
+
 # 插件设置
 settings:
   # 是否启用调试模式，启用后会在控制台输出详细调试信息
@@ -75,10 +78,8 @@ cloudflare:
   # 使用的模型名称，不推荐更改，可以是任何一个Text-Generation模型
   model: "@cf/moonshotai/kimi-k2.5"
 
-# OpenAI 兼容 API 配置（支持自定义 OpenAI 接口）
+# OpenAI 兼容 API 配置（provider 设为 openai 时使用）
 openai:
-  # 是否启用 OpenAI 兼容模式（启用后将优先使用此配置）
-  enabled: false
   # Based API 地址（支持自定义地址，如 OpenAI 官方、Azure OpenAI、本地模型等）
   # 示例：
   #   - OpenAI 官方: https://api.openai.com/v1/chat/completions

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,16 +1,13 @@
 # 配置版本，请勿修改
-version: 3.7.3
-
-# AI 提供商选择: cloudflare 或 openai（默认 cloudflare）
-provider: cloudflare
+version: 3.7.4
 
 # 插件设置
 settings:
   # 是否启用调试模式，启用后会在控制台输出详细调试信息
   debug: false
-  # 是否启用猫娘模式，启用后Fancy将扮演猫娘，注意某些模型(特别是国产模型如DeepSeek)可能会拒绝这个要求
+  # 是否启用猫娘模式，启用后Fancy将扮演猫娘，注意某些模型可能会拒绝这个要求
   meow: true
-  # 是否启用流式输出，启用后AI回复将逐字流式显示，关闭后等待完整回复再显示
+  # 如果支持流式输出但玩家没有设置，是否默认启用流式输出
   streaming: true
   # 补充系统提示词（会自动追加到基础系统提示词后面，不加就留空；注意如果是角色扮演类提示词请关闭Meow模式）
   supplementary_prompt: ""
@@ -20,8 +17,10 @@ settings:
   # 对于推理模型（如 gpt-oss-120b、deepseek-reasoner、kimi-k2.5 等），建议设置为 120-300 秒
   # 对于普通模型（如 gpt-4o、gpt-4o-mini），建议设置为 60-120 秒
   api_timeout_seconds: 120
-  # Token（字符数）剩余警告阈值
-  token_warning_threshold: 100
+  # 上下文窗口剩余警告阈值
+  context_window_warning_threshold: 500
+  # 上下文窗口大小上限
+  context_window_limit: 256000
   # 是否启用匿名错误上报，帮助开发者改进插件
   auto_report: true  
   # 是否启用自动更新检查
@@ -64,12 +63,8 @@ settings:
     - scoreboard
     - tag
 
-# 公告配置
-notice:
-  # 玩家加入时是否显示插件公告（需要 FancyHelper.notice 权限）
-  show_on_join: true
-  # 每隔多久从服务器拉取公告（单位：分钟），默认 5 分钟
-  refresh_interval: 5
+# 提供商选择（接受参数：cloudflare/openai）
+provider: cloudflare
 
 # CloudFlare Workers AI 配置
 cloudflare:
@@ -78,27 +73,23 @@ cloudflare:
   # 使用的模型名称，不推荐更改，可以是任何一个Text-Generation模型
   model: "@cf/moonshotai/kimi-k2.5"
 
-# OpenAI 兼容 API 配置（provider 设为 openai 时使用）
+# OpenAI 兼容端点配置（provider 设为 openai 时使用）
 openai:
   # Based API 地址（支持自定义地址，如 OpenAI 官方、Azure OpenAI、本地模型等）
   # 示例：
-  #   - OpenAI 官方: https://api.openai.com/v1/chat/completions
+  #   - OpenAI: https://api.openai.com/v1/chat/completions
   #   - DeepSeek: https://api.deepseek.com/chat/completions
-  #   - Ollama (本地): http://localhost:11434/v1/chat/completions
-  #   - 阿里云通义千问: https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+  #   - Ollama: http://localhost:11434/v1/chat/completions
   #   - Kimi开放平台: https://api.moonshot.cn/v1/chat/completions
-  #   - 其他兼容 OpenAI 格式的 API
-  api_url: https://api.openai.com/v1/chat/completions
+  #   - 其他使用 OpenAI 兼容端点的地址
+  api_url: https://api.deepseek.com/chat/completions
   # API 密钥
   api_key: your-openai-api-key
   # 使用的模型名称
   # 示例：
-  #   - OpenAI: gpt-4o, gpt-4o-mini, o1-preview, o1-mini
-  #   - DeepSeek: deepseek-chat, deepseek-reasoner
-  #   - Ollama: llama3, mistral
-  #   - Kimi开放平台: kimi-k2.5
-  #   - 阿里云通义千问: qwen3-max
-  model: gpt-4o
+  #   - DeepSeek: DeepSeek-V4-Pro,DeepSeek-V4-Flash
+  #   - Kimi开放平台: kimi-k2.6
+  model: DeepSeek-V4-Pro
 
 # 副模型设置
 # 注意：CloudFlare使用主模型的cf_key，OpenAI使用主模型的api_url和api_key
@@ -112,7 +103,7 @@ co-model:
   # OpenAI 兼容 API （仅配置模型名称，APIURL和key使用主模型设置）
   openai:
     # 使用的模型名称，推荐使用轻量级模型
-    model: gpt-4o-mini
+    model: DeepSeek-V4-Flash
 
 # Metaso AI 搜索配置（秘塔AI搜索API，提供更强大的AI网络搜索能力，开启时优先级最高）
 metaso:
@@ -138,3 +129,9 @@ tavily:
   # 是否包含原始内容（可能增加响应时间）
   include_raw_content: false
 
+# 公告配置
+notice:
+  # 玩家加入时是否显示插件公告（需要 FancyHelper.notice 权限）
+  show_on_join: true
+  # 每隔多久从服务器拉取公告（单位：分钟），默认 5 分钟
+  refresh_interval: 5

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: FancyHelper
-version: 3.7.3
+version: 3.7.4
 main: org.YanPl.FancyHelper
 api-version: '1.18'
 softdepend: [ ProtocolLib ]

--- a/src/test/java/org/YanPl/manager/ConfigManagerTest.java
+++ b/src/test/java/org/YanPl/manager/ConfigManagerTest.java
@@ -92,13 +92,23 @@ class ConfigManagerTest {
     }
 
     @Test
-    @DisplayName("isOpenAiEnabled 应返回配置值")
-    void testIsOpenAiEnabled_ReturnsConfigValue() {
-        when(config.getBoolean("openai.enabled", false)).thenReturn(true);
+    @DisplayName("getProvider 应返回 cloudflare 当配置为 cloudflare")
+    void testGetProvider_ReturnsCloudflare() {
+        when(config.getString("provider", "cloudflare")).thenReturn("cloudflare");
 
-        boolean result = configManager.isOpenAiEnabled();
+        String result = configManager.getProvider();
 
-        assertTrue(result);
+        assertEquals("cloudflare", result);
+    }
+
+    @Test
+    @DisplayName("getProvider 应返回 openai 当配置为 openai")
+    void testGetProvider_ReturnsOpenAI() {
+        when(config.getString("provider", "cloudflare")).thenReturn("openai");
+
+        String result = configManager.getProvider();
+
+        assertEquals("openai", result);
     }
 
     @Test

--- a/src/test/java/org/YanPl/manager/ConfigManagerTest.java
+++ b/src/test/java/org/YanPl/manager/ConfigManagerTest.java
@@ -163,13 +163,23 @@ class ConfigManagerTest {
     }
 
     @Test
-    @DisplayName("getTokenWarningThreshold 应返回配置值")
-    void testGetTokenWarningThreshold_ReturnsConfigValue() {
-        when(config.getInt("settings.token_warning_threshold", 500)).thenReturn(1000);
+    @DisplayName("getContextWindowWarningThreshold 应返回配置值")
+    void testGetContextWindowWarningThreshold_ReturnsConfigValue() {
+        when(config.getInt("settings.context_window_warning_threshold", 500)).thenReturn(1000);
 
-        int result = configManager.getTokenWarningThreshold();
+        int result = configManager.getContextWindowWarningThreshold();
 
         assertEquals(1000, result);
+    }
+
+    @Test
+    @DisplayName("getContextWindowLimit 应返回配置值")
+    void testGetContextWindowLimit_ReturnsConfigValue() {
+        when(config.getInt("settings.context_window_limit", 12800)).thenReturn(32000);
+
+        int result = configManager.getContextWindowLimit();
+
+        assertEquals(32000, result);
     }
 
     @Test


### PR DESCRIPTION
## 变更内容

- **呼吸动画**: 改为 1.6s 周期，6 相位，含 3 色 (#FF7800/#D46700/#A15100/#8F5200) 和 3 符号 (⁕/⁜/▪)
- **随机单词**: 添加 "..." 后缀
- **刷新频率**: 状态栏刷新从 0.25s 提升至 0.1s
- **Token 统计**: 状态栏改为仅显示本轮输出量，丢弃累计历史
- **跨 cycle 累计**: 添加 roundOutputTokens，跨工具调用 cycle 累计 token
- **修复呼吸重置**: generationStartTimes 改为 putIfAbsent，防止跨 cycle 重置呼吸相位
- **修复退出显示 0**: 退出 CLI 前刷入流式 token
- **非流式 token**: 非流式路径也正确累积 token
- **输入估算**: 流式路径添加输入 token 估算
- **线程安全**: token 计数器 volatile 确保跨线程可见性
