### PR TITLE
feat: 添加 Plan Mode 规划模式

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -95,6 +95,10 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "yolo":
             case "normal":
             case "smart":
+            case "plan":
+            case "plan_clear_y":
+            case "plan_clear_n":
+            case "plan_start":
             case "confirm":
             case "cancel":
             case "agree":
@@ -189,6 +193,20 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 return true;
             case "smart":
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.SMART);
+                return true;
+            case "plan":
+                plugin.getCliManager().enterPlanMode(player);
+                return true;
+            case "plan_clear_y":
+                plugin.getCliManager().handlePlanClearY(player);
+                return true;
+            case "plan_clear_n":
+                plugin.getCliManager().handlePlanClearN(player);
+                return true;
+            case "plan_start":
+                if (args.length > 1) {
+                    plugin.getCliManager().handlePlanStartMode(player, args[1]);
+                }
                 return true;
             case "confirm":
                 plugin.getCliManager().handleConfirm(player);
@@ -998,7 +1016,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
             List<String> subCommands = new ArrayList<>(Arrays.asList(
-                "reload", "status", "yolo", "normal", "smart", "checkupdate", "upgrade",
+                "reload", "status", "yolo", "normal", "smart", "plan", "checkupdate", "upgrade",
                 "read", "set", "settings", "tools", "display", "streaming", "toggle",
                 "notice", "retry", "todo", "memory", "mem", "confirm",
                 "cancel", "agree", "thought", "select", "exempt_anti_loop",
@@ -1030,6 +1048,10 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         } else if (args.length == 3 && args[0].equalsIgnoreCase("lib") && args[1].equalsIgnoreCase("install")) {
             return Arrays.asList("protocolib").stream()
                     .filter(s -> s.startsWith(args[2].toLowerCase()))
+                    .collect(Collectors.toList());
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("plan_start")) {
+            return Arrays.asList("normal", "smart", "yolo").stream()
+                    .filter(s -> s.startsWith(args[1].toLowerCase()))
                     .collect(Collectors.toList());
         } else if (args.length == 2 && args[0].equalsIgnoreCase("skill")) {
             List<String> skillSubCommands = new ArrayList<>(Arrays.asList("list", "info", "load"));

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -48,6 +48,10 @@ public class CLIManager {
     private final File yoloAgreedPlayersFile;
     private final File yoloModePlayersFile;
     private final File smartModePlayersFile;
+    private final File planModePlayersFile;
+    private final Set<UUID> planModePlayers = new HashSet<>();
+    private final Set<UUID> pendingPlanContextClear = new HashSet<>();
+    private final Set<UUID> pendingPlanStartMode = new HashSet<>();
     private final Map<UUID, PendingSmartAction> pendingSmartActions = new ConcurrentHashMap<>();
     private final Map<UUID, DialogueSession> sessions = new ConcurrentHashMap<>();
     private final Map<UUID, Boolean> isGenerating = new ConcurrentHashMap<>();
@@ -128,10 +132,12 @@ public class CLIManager {
         this.yoloAgreedPlayersFile = new File(plugin.getDataFolder(), "yolo_agreed_players.txt");
         this.yoloModePlayersFile = new File(plugin.getDataFolder(), "yolo_mode_players.txt");
         this.smartModePlayersFile = new File(plugin.getDataFolder(), "smart_mode_players.txt");
+        this.planModePlayersFile = new File(plugin.getDataFolder(), "plan_mode_players.txt");
         loadAgreedPlayers();
         loadYoloAgreedPlayers();
         loadYoloModePlayers();
         loadSmartModePlayers();
+        loadPlanModePlayers();
         startTimeoutTask();
         startThinkingTask();
         startLogCleanupTask();
@@ -271,11 +277,54 @@ public class CLIManager {
             for (UUID uuid : smartModePlayers) {
                 lines.add(uuid.toString());
             }
-            java.nio.file.Files.write(smartModePlayersFile.toPath(), lines, 
-                java.nio.file.StandardOpenOption.CREATE, 
+            java.nio.file.Files.write(smartModePlayersFile.toPath(), lines,
+                java.nio.file.StandardOpenOption.CREATE,
                 java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
         } catch (IOException e) {
             plugin.getLogger().warning("无法保存 SMART 模式玩家列表: " + e.getMessage());
+            plugin.getCloudErrorReport().report(e);
+        }
+    }
+
+    public void loadPlanModePlayers() {
+        planModePlayers.clear();
+        if (!planModePlayersFile.exists()) return;
+        try {
+            List<String> lines = java.nio.file.Files.readAllLines(planModePlayersFile.toPath());
+            for (String line : lines) {
+                try {
+                    planModePlayers.add(UUID.fromString(line.trim()));
+                } catch (IllegalArgumentException ignored) {}
+            }
+        } catch (IOException e) {
+            plugin.getLogger().warning("无法加载处于 Plan 模式的玩家列表: " + e.getMessage());
+            plugin.getCloudErrorReport().report(e);
+        }
+    }
+
+    private void savePlanModeState(UUID uuid, boolean isPlan) {
+        if (isPlan) {
+            if (planModePlayers.add(uuid)) {
+                writePlanModePlayers();
+            }
+        } else {
+            if (planModePlayers.remove(uuid)) {
+                writePlanModePlayers();
+            }
+        }
+    }
+
+    private void writePlanModePlayers() {
+        try {
+            List<String> lines = new ArrayList<>();
+            for (UUID uuid : planModePlayers) {
+                lines.add(uuid.toString());
+            }
+            java.nio.file.Files.write(planModePlayersFile.toPath(), lines,
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            plugin.getLogger().warning("无法保存 Plan 模式玩家列表: " + e.getMessage());
             plugin.getCloudErrorReport().report(e);
         }
     }
@@ -956,6 +1005,8 @@ public class CLIManager {
                 session.setMode(DialogueSession.Mode.YOLO);
             } else if (smartModePlayers.contains(uuid)) {
                 session.setMode(DialogueSession.Mode.SMART);
+            } else if (planModePlayers.contains(uuid)) {
+                session.setMode(DialogueSession.Mode.PLAN);
             }
             
             // 先将会话放入 Map，确保后续操作能获取到正确的模式
@@ -1112,6 +1163,8 @@ public class CLIManager {
         activeCLIPayers.remove(uuid);
         pendingAgreementPlayers.remove(uuid);
         pendingYoloAgreementPlayers.remove(uuid);
+        pendingPlanContextClear.remove(uuid);
+        pendingPlanStartMode.remove(uuid);
         sessions.remove(uuid);
         isGenerating.remove(uuid);
         generationStates.remove(uuid);
@@ -1127,6 +1180,14 @@ public class CLIManager {
         UUID uuid = player.getUniqueId();
         DialogueSession session = sessions.get(uuid);
         if (session == null) return;
+
+        if (targetMode == DialogueSession.Mode.PLAN) {
+            enterPlanMode(player);
+            return;
+        }
+
+        // 退出 Plan 模式
+        savePlanModeState(uuid, false);
 
         if (targetMode == DialogueSession.Mode.YOLO) {
             if (!yoloAgreedPlayers.contains(uuid)) {
@@ -1172,6 +1233,218 @@ public class CLIManager {
 
         player.spigot().sendMessage(message);
         player.sendMessage(ChatColor.RED + "===============");
+    }
+
+    /**
+     * 进入 Plan Mode
+     */
+    public void enterPlanMode(Player player) {
+        UUID uuid = player.getUniqueId();
+        DialogueSession session = sessions.get(uuid);
+        if (session == null) return;
+
+        // 如果已经在 Plan Mode，无需重复进入
+        if (session.getMode() == DialogueSession.Mode.PLAN) {
+            player.sendMessage(ChatColor.YELLOW + "已在 Plan Mode 中。");
+            return;
+        }
+
+        // 如果有历史消息，询问是否清空上下文
+        if (!session.getHistory().isEmpty()) {
+            pendingPlanContextClear.add(uuid);
+            player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
+            player.sendMessage(ChatColor.WHITE + "进入 Plan Mode 前，是否清空上下文？");
+
+            TextComponent yBtn = new TextComponent(ChatColor.GREEN + "[ Y ] 清空");
+            yBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_clear_y"));
+            yBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("清空对话历史后进入 Plan Mode")));
+
+            TextComponent spacer = new TextComponent("  ");
+
+            TextComponent nBtn = new TextComponent(ChatColor.RED + "[ N ] 保留");
+            nBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_clear_n"));
+            nBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("保留对话历史并进入 Plan Mode")));
+
+            TextComponent message = new TextComponent("");
+            message.addExtra(yBtn);
+            message.addExtra(spacer);
+            message.addExtra(nBtn);
+
+            player.spigot().sendMessage(message);
+            player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
+            return;
+        }
+
+        activatePlanMode(player);
+    }
+
+    /**
+     * 激活 Plan Mode（清空上下文后直接进入）
+     */
+    private void activatePlanMode(Player player) {
+        UUID uuid = player.getUniqueId();
+        DialogueSession session = sessions.get(uuid);
+        if (session == null) return;
+
+        session.setMode(DialogueSession.Mode.PLAN);
+        savePlanModeState(uuid, true);
+        saveYoloModeState(uuid, false);
+        saveSmartModeState(uuid, false);
+
+        sendEnterMessage(player);
+        player.sendMessage(ChatColor.AQUA + "◈ 已进入 Plan Mode。在此模式下 Fancy 仅做规划，不执行任何操作。");
+
+        // 触发 AI 使用 Plan Mode 提示词响应
+        isGenerating.put(uuid, true);
+        generationStates.put(uuid, GenerationStatus.THINKING);
+        generationStartTimes.putIfAbsent(uuid, System.currentTimeMillis());
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final String systemPrompt = promptManager.getPlanModeSystemPrompt(player);
+            try {
+                AIResponse response = ai.chat(session, systemPrompt);
+                if (!plugin.isEnabled()) return;
+                Bukkit.getScheduler().runTask(plugin, () -> handleAIResponse(player, response));
+            } catch (IOException e) {
+                plugin.getCloudErrorReport().report(e);
+                if (!plugin.isEnabled()) return;
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    isGenerating.put(uuid, false);
+                    generationStates.put(uuid, GenerationStatus.ERROR);
+                    player.sendMessage(ChatColor.RED + "Plan Mode 初始化失败: " + e.getMessage());
+                });
+            }
+        });
+    }
+
+    /**
+     * 处理 Plan Mode 上下文清空确认 (Y)
+     */
+    public void handlePlanClearY(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (!pendingPlanContextClear.contains(uuid)) return;
+        pendingPlanContextClear.remove(uuid);
+
+        DialogueSession session = sessions.get(uuid);
+        if (session != null) {
+            session.clearHistory();
+        }
+        activatePlanMode(player);
+    }
+
+    /**
+     * 处理 Plan Mode 上下文清空确认 (N)
+     */
+    public void handlePlanClearN(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (!pendingPlanContextClear.contains(uuid)) return;
+        pendingPlanContextClear.remove(uuid);
+
+        activatePlanMode(player);
+    }
+
+    /**
+     * 处理 Plan Mode 的 #start 工具：显示执行模式选择 UI
+     */
+    public void handlePlanStart(Player player) {
+        UUID uuid = player.getUniqueId();
+        DialogueSession session = sessions.get(uuid);
+        if (session == null || session.getMode() != DialogueSession.Mode.PLAN) return;
+
+        pendingPlanStartMode.add(uuid);
+        setGenerating(uuid, false, GenerationStatus.WAITING_CHOICE);
+
+        player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
+        player.sendMessage(ChatColor.GOLD + " ◆ 规划已完成！");
+        player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
+        player.sendMessage(ChatColor.WHITE + " • 以何种方式开始任务？");
+
+        // Normal 模式
+        TextComponent normalBtn = new TextComponent(ChatColor.GREEN + " » Normal ");
+        normalBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_start normal"));
+        normalBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "每次执行命令前都需要确认")));
+        player.spigot().sendMessage(normalBtn);
+        player.sendMessage(ChatColor.GRAY + "   每次执行命令前都需要确认");
+
+        // Smart 模式
+        TextComponent smartBtn = new TextComponent(ChatColor.BLUE + " » Smart ");
+        smartBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_start smart"));
+        smartBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "AI 评估风险，高风险操作需要确认")));
+        player.spigot().sendMessage(smartBtn);
+        player.sendMessage(ChatColor.GRAY + "   AI 评估风险，高风险操作需要确认");
+
+        // Yolo 模式
+        TextComponent yoloBtn = new TextComponent(ChatColor.RED + " » Yolo ");
+        yoloBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_start yolo"));
+        yoloBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "自动执行大部分命令（风险命令仍需确认）")));
+        player.spigot().sendMessage(yoloBtn);
+        player.sendMessage(ChatColor.GRAY + "   自动执行大部分命令（风险命令仍需确认）");
+
+        player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
+    }
+
+    /**
+     * 处理 Plan Mode 执行模式选择
+     */
+    public void handlePlanStartMode(Player player, String modeStr) {
+        UUID uuid = player.getUniqueId();
+        if (!pendingPlanStartMode.contains(uuid)) return;
+        pendingPlanStartMode.remove(uuid);
+
+        DialogueSession.Mode targetMode;
+        String modeDisplayName;
+        switch (modeStr.toLowerCase()) {
+            case "yolo":
+                // YOLO 需要先同意协议
+                if (!yoloAgreedPlayers.contains(uuid)) {
+                    sendYoloWarning(player);
+                    pendingYoloAgreementPlayers.add(uuid);
+                    // 同时保存 plan start mode 信息，等 YOLO 同意后再继续
+                    // 先把 session 设为 YOLO pending 状态
+                    player.sendMessage(ChatColor.YELLOW + "请先同意 YOLO 模式协议后再继续。");
+                    return;
+                }
+                targetMode = DialogueSession.Mode.YOLO;
+                modeDisplayName = "YOLO";
+                break;
+            case "smart":
+                targetMode = DialogueSession.Mode.SMART;
+                modeDisplayName = "Smart";
+                break;
+            default:
+                targetMode = DialogueSession.Mode.NORMAL;
+                modeDisplayName = "Normal";
+                break;
+        }
+
+        final DialogueSession.Mode finalMode = targetMode;
+        final String finalDisplayName = modeDisplayName;
+
+        // 延迟 0.3 秒 (6 ticks) 后发送确认并开始执行
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (!player.isOnline()) return;
+
+            player.sendMessage(ChatColor.GOLD + " ◆ 好的，我将以 " + finalDisplayName + " 执行此任务。");
+
+            DialogueSession session = sessions.get(uuid);
+            if (session == null) return;
+
+            // 切换模式
+            session.setMode(finalMode);
+            savePlanModeState(uuid, false);
+            if (finalMode == DialogueSession.Mode.YOLO) {
+                saveYoloModeState(uuid, true);
+            } else if (finalMode == DialogueSession.Mode.SMART) {
+                saveSmartModeState(uuid, true);
+            }
+
+            // 反馈给 AI：规划完成，开始执行
+            String feedback = "#start_result: 玩家选择了 " + finalDisplayName + " 模式。现在开始执行规划好的任务。";
+            session.appendLog("PLAN_START", "Plan mode ended. Execution mode: " + finalDisplayName);
+
+            // 使用 feedbackToAI 触发 AI 响应（复用现有流式/非流式逻辑）
+            feedbackToAI(player, feedback);
+        }, 6L);
     }
 
     /**
@@ -1429,6 +1702,18 @@ public class CLIManager {
                 player.sendMessage(ChatColor.GRAY + "⇒ 已取消进入 YOLO 模式。");
             } else {
                 player.sendMessage(ChatColor.RED + "请发送 agree 以进入 YOLO 模式，或发送 stop 取消。");
+            }
+            return true;
+        }
+
+        // 如果玩家在等待 Plan Mode 上下文清空确认
+        if (pendingPlanContextClear.contains(uuid)) {
+            if (message.equalsIgnoreCase("y")) {
+                handlePlanClearY(player);
+            } else if (message.equalsIgnoreCase("n")) {
+                handlePlanClearN(player);
+            } else {
+                player.sendMessage(ChatColor.RED + "请选择 [Y] 清空上下文 或 [N] 保留上下文。");
             }
             return true;
         }
@@ -2050,7 +2335,7 @@ public class CLIManager {
         });
         
         // 估算本轮输入的 prompt tokens 并记入 session
-        String systemPrompt = promptManager.getBaseSystemPrompt(player, matchedSkills);
+        String systemPrompt = promptManager.getSystemPromptForSession(player, matchedSkills, session.getMode());
         String modelName = plugin.getConfigManager().getCloudflareModel();
         int estimatedInput = DialogueSession.calculateTokens(systemPrompt, modelName)
             + session.getEstimatedTokens(modelName) + 3;
@@ -2113,7 +2398,9 @@ public class CLIManager {
     }
 
     private void processNonStreamingMessage(Player player, String message, List<org.YanPl.model.Skill> matchedSkills) throws IOException {
-        String systemPrompt = promptManager.getBaseSystemPrompt(player, matchedSkills);
+        DialogueSession nsSession = sessions.get(player.getUniqueId());
+        String systemPrompt = promptManager.getSystemPromptForSession(player, matchedSkills,
+                nsSession != null ? nsSession.getMode() : DialogueSession.Mode.NORMAL);
         AIResponse response = ai.chat(sessions.get(player.getUniqueId()), systemPrompt);
         
         if (!plugin.isEnabled()) return;
@@ -2358,7 +2645,7 @@ public class CLIManager {
         String toolCall = "";
 
         // 定义已知工具列表
-        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         boolean foundTool = false;
@@ -2518,7 +2805,7 @@ public class CLIManager {
         cleanResponse = cleanResponse.replaceAll("(?i)^思考过程:.*?\n", "");
         cleanResponse = cleanResponse.trim();
         
-        List<String> knownTools = Arrays.asList("#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         while (currentPos < cleanResponse.length()) {
@@ -2636,7 +2923,7 @@ public class CLIManager {
             
             try {
                 // continueGeneration 不需要匹配新 Skills，使用空列表
-                AIResponse response = ai.chat(session, promptManager.getBaseSystemPrompt(player, Collections.emptyList()));
+                AIResponse response = ai.chat(session, promptManager.getSystemPromptForSession(player, Collections.emptyList(), session.getMode()));
                 if (!plugin.isEnabled()) return;
                 Bukkit.getScheduler().runTask(plugin, () -> {
                     handleAIResponse(player, response);
@@ -2833,7 +3120,7 @@ public class CLIManager {
         if (!plugin.isEnabled()) return;
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             // feedbackToAI 不需要匹配新 Skills，使用空列表
-            final String systemPrompt = promptManager.getBaseSystemPrompt(player, Collections.emptyList()); // 在 try 块外部定义
+            final String systemPrompt = promptManager.getSystemPromptForSession(player, Collections.emptyList(), session.getMode());
             
             // 设置重试回调，向玩家显示重试提示
             ai.setRetryCallback((statusCode, retryMessage) -> {
@@ -3372,6 +3659,8 @@ public class CLIManager {
             modeTag = new TextComponent(ChatColor.GREEN + " (Normal) ");
         } else if (mode == DialogueSession.Mode.SMART) {
             modeTag = new TextComponent(ChatColor.BLUE + " (SMART) ");
+        } else if (mode == DialogueSession.Mode.PLAN) {
+            modeTag = new TextComponent(ChatColor.AQUA + " (Plan) ");
         } else {
             modeTag = new TextComponent(ChatColor.RED + " (YOLO) ");
         }

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1389,7 +1389,6 @@ public class CLIManager {
     public void handlePlanStartMode(Player player, String modeStr) {
         UUID uuid = player.getUniqueId();
         if (!pendingPlanStartMode.contains(uuid)) return;
-        pendingPlanStartMode.remove(uuid);
 
         DialogueSession.Mode targetMode;
         String modeDisplayName;
@@ -1399,8 +1398,7 @@ public class CLIManager {
                 if (!yoloAgreedPlayers.contains(uuid)) {
                     sendYoloWarning(player);
                     pendingYoloAgreementPlayers.add(uuid);
-                    // 同时保存 plan start mode 信息，等 YOLO 同意后再继续
-                    // 先把 session 设为 YOLO pending 状态
+                    // 保留 pendingPlanStartMode，等 YOLO 同意后由 handleChat 继续
                     player.sendMessage(ChatColor.YELLOW + "请先同意 YOLO 模式协议后再继续。");
                     return;
                 }
@@ -1416,6 +1414,8 @@ public class CLIManager {
                 modeDisplayName = "Normal";
                 break;
         }
+
+        pendingPlanStartMode.remove(uuid);
 
         final DialogueSession.Mode finalMode = targetMode;
         final String finalDisplayName = modeDisplayName;
@@ -1696,10 +1696,20 @@ public class CLIManager {
             if (message.equalsIgnoreCase("agree")) {
                 pendingYoloAgreementPlayers.remove(uuid);
                 saveYoloAgreedPlayer(uuid);
-                switchMode(player, DialogueSession.Mode.YOLO);
+                // 如果 YOLO 同意来自 Plan Mode 的 #start 流程，继续 plan 执行
+                if (pendingPlanStartMode.contains(uuid)) {
+                    handlePlanStartMode(player, "yolo");
+                } else {
+                    switchMode(player, DialogueSession.Mode.YOLO);
+                }
             } else if (message.equalsIgnoreCase("stop")) {
                 pendingYoloAgreementPlayers.remove(uuid);
-                player.sendMessage(ChatColor.GRAY + "⇒ 已取消进入 YOLO 模式。");
+                if (pendingPlanStartMode.contains(uuid)) {
+                    // Plan 启动中的 YOLO 取消：重新显示模式选择 UI
+                    handlePlanStart(player);
+                } else {
+                    player.sendMessage(ChatColor.GRAY + "⇒ 已取消进入 YOLO 模式。");
+                }
             } else {
                 player.sendMessage(ChatColor.RED + "请发送 agree 以进入 YOLO 模式，或发送 stop 取消。");
             }

--- a/src/main/java/org/YanPl/manager/GuiManager.java
+++ b/src/main/java/org/YanPl/manager/GuiManager.java
@@ -40,34 +40,44 @@ public class GuiManager implements Listener {
         }
 
         // 1. Normal 模式
-        ItemStack normalItem = createItem(Material.LIME_DYE, ColorUtil.translateCustomColors("&a&lNormal 模式"), 
+        ItemStack normalItem = createItem(Material.LIME_DYE, ColorUtil.translateCustomColors("&a&lNormal 模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"),
                 ColorUtil.translateCustomColors("&7普通模式"),
                 ColorUtil.translateCustomColors("&7AI 执行敏感操作需手动确认"),
                 "",
                 ColorUtil.translateCustomColors("&e▸ 点击选择此模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"));
-        inv.setItem(2, normalItem);
+        inv.setItem(1, normalItem);
 
         // 2. SMART 模式
-        ItemStack smartItem = createItem(Material.BLUE_DYE, ColorUtil.translateCustomColors("&9&lSMART 模式"), 
+        ItemStack smartItem = createItem(Material.BLUE_DYE, ColorUtil.translateCustomColors("&9&lSMART 模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"),
                 ColorUtil.translateCustomColors("&7智能模式"),
                 ColorUtil.translateCustomColors("&7AI 会评估操作风险，高风险需确认"),
                 "",
                 ColorUtil.translateCustomColors("&e▸ 点击选择此模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"));
-        inv.setItem(4, smartItem);
+        inv.setItem(3, smartItem);
 
-        // 3. YOLO 模式
-        ItemStack yoloItem = createItem(Material.RED_DYE, ColorUtil.translateCustomColors("&c&lYOLO 模式"), 
+        // 3. Plan 模式
+        ItemStack planItem = createItem(Material.CYAN_DYE, ColorUtil.translateCustomColors("&b&lPlan 模式"),
+                ColorUtil.translateCustomColors("&8&m------------------------"),
+                ColorUtil.translateCustomColors("&7规划模式"),
+                ColorUtil.translateCustomColors("&7AI 只做搜索、规划，不执行命令"),
+                "",
+                ColorUtil.translateCustomColors("&e▸ 点击选择此模式"),
+                ColorUtil.translateCustomColors("&8&m------------------------"));
+        inv.setItem(5, planItem);
+
+        // 4. YOLO 模式
+        ItemStack yoloItem = createItem(Material.RED_DYE, ColorUtil.translateCustomColors("&c&lYOLO 模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"),
                 ColorUtil.translateCustomColors("&7激进模式"),
                 ColorUtil.translateCustomColors("&7AI 将自动执行大部分命令"),
                 "",
                 ColorUtil.translateCustomColors("&e▸ 点击选择此模式"),
                 ColorUtil.translateCustomColors("&8&m------------------------"));
-        inv.setItem(6, yoloItem);
+        inv.setItem(7, yoloItem);
 
         player.openInventory(inv);
     }
@@ -125,7 +135,7 @@ public class GuiManager implements Listener {
 
         ItemStack item;
         if (mode == DialogueSession.Mode.NORMAL) {
-            item = createItem(Material.LIME_DYE, ColorUtil.translateCustomColors("&a&l当前模式: Normal"), 
+            item = createItem(Material.LIME_DYE, ColorUtil.translateCustomColors("&a&l当前模式: Normal"),
                     ColorUtil.translateCustomColors("&8&m------------------------"),
                     ColorUtil.translateCustomColors("&7当前为 &a普通模式"),
                     ColorUtil.translateCustomColors("&7AI 执行敏感操作需手动确认"),
@@ -133,15 +143,23 @@ public class GuiManager implements Listener {
                     ColorUtil.translateCustomColors("&e▸ 点击切换至 SMART 模式"),
                     ColorUtil.translateCustomColors("&8&m------------------------"));
         } else if (mode == DialogueSession.Mode.SMART) {
-            item = createItem(Material.BLUE_DYE, ColorUtil.translateCustomColors("&9&l当前模式: SMART"), 
+            item = createItem(Material.BLUE_DYE, ColorUtil.translateCustomColors("&9&l当前模式: SMART"),
                     ColorUtil.translateCustomColors("&8&m------------------------"),
                     ColorUtil.translateCustomColors("&7当前为 &9智能模式"),
                     ColorUtil.translateCustomColors("&7AI 会评估操作风险，高风险需确认"),
                     "",
+                    ColorUtil.translateCustomColors("&e▸ 点击切换至 Plan 模式"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"));
+        } else if (mode == DialogueSession.Mode.PLAN) {
+            item = createItem(Material.CYAN_DYE, ColorUtil.translateCustomColors("&b&l当前模式: Plan"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"),
+                    ColorUtil.translateCustomColors("&7当前为 &b规划模式"),
+                    ColorUtil.translateCustomColors("&7AI 只做搜索、规划，不执行命令"),
+                    "",
                     ColorUtil.translateCustomColors("&e▸ 点击切换至 YOLO 模式"),
                     ColorUtil.translateCustomColors("&8&m------------------------"));
         } else {
-            item = createItem(Material.RED_DYE, ColorUtil.translateCustomColors("&c&l当前模式: YOLO"), 
+            item = createItem(Material.RED_DYE, ColorUtil.translateCustomColors("&c&l当前模式: YOLO"),
                     ColorUtil.translateCustomColors("&8&m------------------------"),
                     ColorUtil.translateCustomColors("&7当前为 &c激进模式"),
                     ColorUtil.translateCustomColors("&7AI 将自动执行大部分命令"),
@@ -216,6 +234,8 @@ public class GuiManager implements Listener {
             if (currentMode == DialogueSession.Mode.NORMAL) {
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.SMART);
             } else if (currentMode == DialogueSession.Mode.SMART) {
+                plugin.getCliManager().switchMode(player, DialogueSession.Mode.PLAN);
+            } else if (currentMode == DialogueSession.Mode.PLAN) {
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.YOLO);
             } else {
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.NORMAL);
@@ -251,17 +271,22 @@ public class GuiManager implements Listener {
         
         // 模式选择菜单处理
         if (event.getView().getTitle().equals(MODE_SELECTION_TITLE)) {
-            if (slot == 2) {
+            if (slot == 1) {
                 // Normal 模式
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.NORMAL);
                 player.closeInventory();
                 player.playSound(player.getLocation(), "ui.button.click", 1, 1);
-            } else if (slot == 4) {
+            } else if (slot == 3) {
                 // SMART 模式
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.SMART);
                 player.closeInventory();
                 player.playSound(player.getLocation(), "ui.button.click", 1, 1);
-            } else if (slot == 6) {
+            } else if (slot == 5) {
+                // Plan 模式
+                plugin.getCliManager().switchMode(player, DialogueSession.Mode.PLAN);
+                player.closeInventory();
+                player.playSound(player.getLocation(), "ui.button.click", 1, 1);
+            } else if (slot == 7) {
                 // YOLO 模式
                 plugin.getCliManager().switchMode(player, DialogueSession.Mode.YOLO);
                 player.closeInventory();

--- a/src/main/java/org/YanPl/manager/PromptManager.java
+++ b/src/main/java/org/YanPl/manager/PromptManager.java
@@ -312,4 +312,123 @@ public class PromptManager {
 
         return sb.toString();
     }
+
+    /**
+     * 根据会话模式获取对应的系统提示词
+     */
+    public String getSystemPromptForSession(org.bukkit.entity.Player player, List<Skill> loadedSkills,
+                                             org.YanPl.model.DialogueSession.Mode mode) {
+        if (mode == org.YanPl.model.DialogueSession.Mode.PLAN) {
+            return getPlanModeSystemPrompt(player);
+        }
+        return getBaseSystemPrompt(player, loadedSkills);
+    }
+
+    /**
+     * 获取 Plan Mode 的系统提示词
+     * Plan Mode 下 AI 只能做规划（搜索、阅读、设计），不能执行命令或修改文件
+     */
+    public String getPlanModeSystemPrompt(org.bukkit.entity.Player player) {
+        StringBuilder sb = new StringBuilder();
+
+        // ==================== Plan Mode / 规划模式 ====================
+        sb.append("[Plan Mode]\n");
+        sb.append("You are in PLAN MODE. Your job is to analyze the task, gather information,\n");
+        sb.append("and design a thorough plan. You CANNOT execute any commands or edit files.\n\n");
+
+        // ==================== Role & Language / 角色与语言 ====================
+        sb.append("[Role]\n");
+        if (plugin.getConfigManager().isMeowEnabled()) {
+            sb.append("You are Fancy, a catgirl Minecraft assistant in plan mode.\n\n");
+        } else {
+            sb.append("You are a Minecraft assistant named Fancy in plan mode.\n\n");
+        }
+
+        sb.append("[Language]\n");
+        sb.append("Default: Simplified Chinese.\n\n");
+
+        // ==================== Basic Rules / 基础规则 ====================
+        sb.append("[Basic Rules]\n");
+        sb.append("1. No Markdown.\n");
+        sb.append("2. Highlight keywords with ** **.\n");
+        sb.append("3. Be concise.\n");
+        sb.append("4. No emoji.\n\n");
+
+        // ==================== Meow Mode / 猫娘模式 ====================
+        if (plugin.getConfigManager().isMeowEnabled()) {
+            sb.append("[Meow Mode]\n");
+            sb.append("1. Always refer to yourself as 'Fancy' or '本喵'.\n");
+            sb.append("2. End EVERY sentence with '喵'.\n");
+            sb.append("3. Keep responses short and lively.\n\n");
+        }
+
+        // ==================== Available Tools in Plan Mode ====================
+        sb.append("[Available Tools in Plan Mode]\n");
+        sb.append("Format: #tool_name: argument\n\n");
+
+        sb.append("[Query]\n");
+        sb.append("  #search: <args>      - Internet/Wiki search.\n");
+        sb.append("  #skill: <id>         - Load Skill knowledge module.\n");
+        sb.append("  #unloadskill: <id>   - Unload a loaded Skill.\n");
+        sb.append("  #webread: <url>      - Fetch and parse a web page.\n");
+        sb.append("  #ask: <json>         - Ask player a question.\n");
+        sb.append("    Fields: question (required), header (max 12 chars), options[] (2-4, each: label + description).\n\n");
+
+        sb.append("[File Tools]\n");
+        if (plugin.getConfigManager().isPlayerToolEnabled(player, "ls")) {
+            sb.append("  #list: <path>    - List directory.\n");
+        }
+        if (plugin.getConfigManager().isPlayerToolEnabled(player, "read")) {
+            sb.append("  #read: <path> [start-end]  - Read file with line numbers.\n");
+        }
+        sb.append("  Note: #edit is NOT available in plan mode.\n\n");
+
+        sb.append("[Task Management]\n");
+        sb.append("  #todo: <json>  - Create/update task list.\n");
+        sb.append("    Required: id, task. Optional: status (pending/in_progress/completed/cancelled).\n");
+        sb.append("    After #todo: end the response immediately.\n\n");
+
+        sb.append("[Plan Mode]\n");
+        sb.append("  #start  - FINISH planning. Call when your plan is complete.\n");
+        sb.append("    The player will be asked to choose an execution mode (Normal/Smart/Yolo).\n");
+        sb.append("    After #start, you will enter execution mode and can use all tools.\n\n");
+
+        // ==================== Plan Mode Rules / 规划模式规则 ====================
+        sb.append("[Plan Mode Rules]\n");
+        sb.append("1. Design a thorough plan before calling #start.\n");
+        sb.append("2. Use #search and #skill to gather necessary knowledge.\n");
+        sb.append("3. Use #todo to organize your plan into clear, ordered steps.\n");
+        sb.append("4. NEVER call #run or #edit in plan mode — these are blocked.\n");
+        sb.append("5. Call #start only when your plan is complete and ready to execute.\n");
+        sb.append("6. The player will choose the execution mode after #start.\n\n");
+
+        // ==================== Usage Guide ====================
+        sb.append("[Usage Guide]\n");
+        sb.append("1. Analyze: understand the player's request thoroughly.\n");
+        sb.append("2. Research: use #search, #skill, or #webread to gather information.\n");
+        sb.append("3. Plan: use #todo to break the task into clear steps.\n");
+        sb.append("4. Start: call #start when the plan is ready.\n\n");
+
+        // ==================== Environment Info / 环境信息 ====================
+        sb.append("[Environment]\n");
+        sb.append("Minecraft Version: ").append(org.bukkit.Bukkit.getBukkitVersion()).append("\n");
+        sb.append("Player: ").append(player.getName()).append("\n");
+        sb.append("Available Commands: ").append(String.join(", ", plugin.getWorkspaceIndexer().getIndexedCommands())).append("\n");
+
+        List<String> skillSummaries = plugin.getSkillManager().getSkillSummariesForPrompt();
+        sb.append("Available Skills:\n");
+        if (skillSummaries.isEmpty()) {
+            sb.append("  (none)\n");
+        } else {
+            for (String summary : skillSummaries) {
+                sb.append("  - ").append(summary).append("\n");
+            }
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        sb.append("Current Time: ").append(now.format(formatter)).append("\n");
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -64,21 +64,19 @@ public class ToolExecutor {
             plugin.getLogger().info("[CLI] 正在为 " + player.getName() + " 执行工具: " + toolName + " (参数: " + args + ")");
         }
 
-        // 显示工具调用信息
-        displayToolCall(player, toolName, args);
-
-        // Plan Mode 工具白名单检查
+        // Plan Mode 工具白名单检查（必须在 displayToolCall 之前，避免显示被拒绝的工具）
         if (session != null && session.getMode() == DialogueSession.Mode.PLAN) {
             if (!isPlanModeTool(toolName)) {
                 String error = "#error: 当前处于 Plan Mode，仅允许规划相关工具。使用 #start 结束规划并开始执行。";
                 cliManager.feedbackToAI(player, error);
-                if (session != null) {
-                    session.setLastError(error);
-                    session.appendLog("PLAN_MODE_BLOCKED", "Blocked tool in plan mode: " + toolName);
-                }
+                session.setLastError(error);
+                session.appendLog("PLAN_MODE_BLOCKED", "Blocked tool in plan mode: " + toolName);
                 return false;
             }
         }
+
+        // 显示工具调用信息
+        displayToolCall(player, toolName, args);
 
         // 执行对应的工具
         boolean success = true;

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -67,6 +67,19 @@ public class ToolExecutor {
         // 显示工具调用信息
         displayToolCall(player, toolName, args);
 
+        // Plan Mode 工具白名单检查
+        if (session != null && session.getMode() == DialogueSession.Mode.PLAN) {
+            if (!isPlanModeTool(toolName)) {
+                String error = "#error: 当前处于 Plan Mode，仅允许规划相关工具。使用 #start 结束规划并开始执行。";
+                cliManager.feedbackToAI(player, error);
+                if (session != null) {
+                    session.setLastError(error);
+                    session.appendLog("PLAN_MODE_BLOCKED", "Blocked tool in plan mode: " + toolName);
+                }
+                return false;
+            }
+        }
+
         // 执行对应的工具
         boolean success = true;
         String lowerToolName = toolName.toLowerCase();
@@ -78,6 +91,9 @@ public class ToolExecutor {
                 break;
             case "#exit":
                 cliManager.exitCLI(player);
+                break;
+            case "#start":
+                handleStartTool(player);
                 break;
             
             // 执行工具
@@ -1892,5 +1908,25 @@ public class ToolExecutor {
             }
         }
         return line;
+    }
+
+    /**
+     * 检查工具是否在 Plan Mode 白名单中
+     */
+    private boolean isPlanModeTool(String toolName) {
+        String lower = toolName.toLowerCase().trim();
+        return switch (lower) {
+            case "#start", "#search", "#skill", "#unloadskill", "#webread",
+                 "#list", "#read", "#todo", "#ask", "#end", "#exit" -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * 处理 #start 工具 — 结束 Plan Mode，显示执行模式选择
+     */
+    private void handleStartTool(Player player) {
+        cliManager.setGenerating(player.getUniqueId(), false, CLIManager.GenerationStatus.WAITING_CHOICE);
+        cliManager.handlePlanStart(player);
     }
 }

--- a/src/main/java/org/YanPl/model/DialogueSession.java
+++ b/src/main/java/org/YanPl/model/DialogueSession.java
@@ -28,7 +28,7 @@ public class DialogueSession {
      * 对话模式
      */
     public enum Mode {
-        NORMAL, YOLO, SMART
+        NORMAL, YOLO, SMART, PLAN
     }
 
     /**


### PR DESCRIPTION
## Summary
- 新增 Plan Mode，AI 在此模式下仅做规划（搜索、阅读、设计），不能执行命令或修改文件
- 进入 Plan Mode 时若有上下文，询问是否清空
- 规划完成后通过 `#start` 工具退出，由玩家选择 Normal/Smart/Yolo 模式开始执行
- Plan Mode 下仅有规划工具可用：`#search` `#skill` `#webread` `#list` `#read` `#todo` `#ask` `#start`
- 调用非规划工具会被拒绝并提示使用 `#start`

## Changes
- `DialogueSession.java` — Mode 枚举添加 `PLAN`
- `CLIManager.java` — Plan Mode 进入/退出/状态持久化/UI 交互
- `PromptManager.java` — Plan Mode 专用系统提示词
- `ToolExecutor.java` — Plan Mode 工具白名单 + `#start` 工具处理
- `CLICommand.java` — `/cli plan` 等子命令 + tab 补全

## Test plan
- [x] 编译通过
- [x] 进入 `/cli plan` → 验证历史上下文清空确认
- [ ] Plan Mode 下 `#run` 被正确拒绝
- [ ] `#start` 后显示 Normal/Smart/Yolo 模式选择 UI
- [x] 选择模式后正确切换并开始执行