### PR TITLE
fix: 支持 Gemma 系列模型的 reasoning 思考字段解析

### DIFF
--- a/src/main/java/org/YanPl/api/CloudFlareAI.java
+++ b/src/main/java/org/YanPl/api/CloudFlareAI.java
@@ -1288,15 +1288,16 @@ public class CloudFlareAI {
         JsonObject bodyJson = new JsonObject();
         bodyJson.addProperty("model", model);
         bodyJson.addProperty("max_tokens", 4096);
-        bodyJson.addProperty("stream", true);
 
         if (useResponsesApi) {
+            // gpt-oss 模型通过 Responses API 不支持流式，走非流式请求
             bodyJson.add("input", messagesArray);
             JsonObject reasoning = new JsonObject();
             reasoning.addProperty("effort", "medium");
             reasoning.addProperty("summary", "detailed");
             bodyJson.add("reasoning", reasoning);
         } else {
+            bodyJson.addProperty("stream", true);
             bodyJson.add("messages", messagesArray);
             if (model.contains("gpt") || model.contains("o1") || model.contains("deepseek-reasoner")) {
                 bodyJson.addProperty("reasoning_effort", "medium");
@@ -1317,8 +1318,22 @@ public class CloudFlareAI {
                     .POST(HttpRequest.BodyPublishers.ofString(bodyString, StandardCharsets.UTF_8))
                     .build();
 
+            if (useResponsesApi) {
+                // gpt-oss 模型使用非流式请求，通过 responseParser 解析
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() != 200) {
+                    throw new IOException("非流式请求失败: " + response.statusCode() + " - " + response.body());
+                }
+                JsonObject responseJson = gson.fromJson(response.body(), JsonObject.class);
+                AIResponse aiResponse = responseParser.parseResponse(responseJson);
+                String fullText = aiResponse != null ? aiResponse.getContent() : "";
+                streamingHandler.feedCompletedText(fullText);
+                session.logAIResponse(buildStreamingLogResponse(fullText));
+                return fullText;
+            }
+
             HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-            
+
             if (response.statusCode() != 200) {
                 String errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
                 throw new IOException("流式请求失败: " + response.statusCode() + " - " + errorBody);

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -314,6 +314,35 @@ public class StreamingHandler {
     }
     
     /**
+     * 处理非流式完成的文本（用于 gpt-oss 等不支持流式的模型）
+     * 将完整文本通过回调机制传递给 UI，触发完成回调
+     * @param fullText 完整的响应文本
+     * @return 原始文本
+     */
+    public String feedCompletedText(String fullText) {
+        if (fullText != null && !fullText.isEmpty() && !isCancelled.get() && onChunkCallback != null) {
+            try {
+                onChunkCallback.accept(fullText);
+            } catch (Exception e) {
+                logger.warning("[Stream] 非流式文本回调异常: " + e.getMessage());
+            }
+        }
+        // 触发完成回调
+        if (!isCancelled.get() && !errorOccurred && onCompleteCallback != null) {
+            try {
+                onCompleteCallback.accept(fullText != null ? fullText : "");
+            } catch (Exception e) {
+                errorOccurred = true;
+                logger.warning("[Stream] 完成回调异常: " + e.getMessage());
+                if (onErrorCallback != null) {
+                    try { onErrorCallback.accept(e); } catch (Exception ignored) {}
+                }
+            }
+        }
+        return fullText != null ? fullText : "";
+    }
+
+    /**
      * 从SSE数据行中提取文本内容
      * 支持多种格式：
      * 1. CloudFlare原生格式: {"response":"text"}

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -439,17 +439,96 @@ public class StreamingHandler {
                 }
             }
 
-            // 3. 尝试解析 CloudFlare 原生 response 格式
+            // 3. 尝试解析 CloudFlare Responses API 非流式格式
+            // {"output":[{"type":"message","content":[{"type":"output_text","text":"..."}]}]}
+            if (json.has("output") && json.get("output").isJsonArray()) {
+                JsonArray output = json.getAsJsonArray("output");
+                for (int i = 0; i < output.size(); i++) {
+                    JsonObject item = output.get(i).getAsJsonObject();
+                    String itemType = item.has("type") ? item.get("type").getAsString() : "";
+                    // 提取 reasoning 内容
+                    if ("reasoning".equals(itemType) && !hasReasoningInChunk) {
+                        hasReasoningInChunk = true;
+                        StringBuilder rcBuilder = new StringBuilder();
+                        // 尝试从 summary 字段解析（可能是数组或字符串）
+                        if (item.has("summary")) {
+                            JsonElement summaryEl = item.get("summary");
+                            if (summaryEl.isJsonArray()) {
+                                JsonArray summaries = summaryEl.getAsJsonArray();
+                                for (int j = 0; j < summaries.size(); j++) {
+                                    JsonObject s = summaries.get(j).getAsJsonObject();
+                                    if (s.has("text") && !s.get("text").isJsonNull()) {
+                                        String text = s.get("text").getAsString();
+                                        if (!text.isEmpty()) {
+                                            if (rcBuilder.length() > 0) rcBuilder.append("\n");
+                                            rcBuilder.append(text);
+                                        }
+                                    }
+                                }
+                            } else if (summaryEl.isJsonPrimitive()) {
+                                String text = summaryEl.getAsString();
+                                if (!text.isEmpty()) {
+                                    rcBuilder.append(text);
+                                }
+                            }
+                        }
+                        // 如果 summary 没有内容，尝试从 content 数组解析
+                        if (rcBuilder.length() == 0 && item.has("content") && item.get("content").isJsonArray()) {
+                            JsonArray reasoningContents = item.getAsJsonArray("content");
+                            for (int j = 0; j < reasoningContents.size(); j++) {
+                                JsonObject c = reasoningContents.get(j).getAsJsonObject();
+                                String ct = c.has("type") ? c.get("type").getAsString() : "";
+                                if (("reasoning_text".equals(ct) || "text".equals(ct)) && c.has("text") && !c.get("text").isJsonNull()) {
+                                    String text = c.get("text").getAsString();
+                                    if (!text.isEmpty()) {
+                                        if (rcBuilder.length() > 0) rcBuilder.append("\n");
+                                        rcBuilder.append(text);
+                                    }
+                                }
+                            }
+                        }
+                        if (rcBuilder.length() > 0) {
+                            if (reasoningStartTime == -1) {
+                                reasoningStartTime = System.currentTimeMillis();
+                            }
+                            thoughtContent.append(rcBuilder);
+                            if (onReasoningCallback != null) {
+                                try { onReasoningCallback.accept(rcBuilder.toString()); } catch (Exception ignored) {}
+                            }
+                        }
+                    }
+                    // 提取消息内容
+                    if ("message".equals(itemType) && item.has("content") && item.get("content").isJsonArray()) {
+                        JsonArray contents = item.getAsJsonArray("content");
+                        for (int j = 0; j < contents.size(); j++) {
+                            JsonObject contentObj = contents.get(j).getAsJsonObject();
+                            String contentType = contentObj.has("type") ? contentObj.get("type").getAsString() : "";
+                            if ("output_text".equals(contentType) && !contentObj.get("text").isJsonNull()) {
+                                String text = contentObj.get("text").getAsString();
+                                if (text != null && !text.isEmpty()) {
+                                    // 首次从 reasoning 切换到 content，标记思考结束
+                                    if (!reasoningCompleteFired && !reasoningJustCompleted && reasoningStartTime != -1 && thoughtContent.length() > 0) {
+                                        reasoningJustCompleted = true;
+                                    }
+                                    return text;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 4. 尝试解析 CloudFlare 原生 response 格式
             if (json.has("response") && !json.get("response").isJsonNull()) {
                 return json.get("response").getAsString();
             }
 
-            // 4. 尝试解析通用 content 格式
+            // 5. 尝试解析通用 content 格式
             if (json.has("content") && !json.get("content").isJsonNull()) {
                 return json.get("content").getAsString();
             }
 
-            // 5. 尝试解析通用 text 格式
+            // 6. 尝试解析通用 text 格式
             if (json.has("text") && !json.get("text").isJsonNull()) {
                 return json.get("text").getAsString();
             }

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -1,6 +1,8 @@
 package org.YanPl.api;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.YanPl.FancyHelper;
 import org.bukkit.entity.Player;

--- a/src/main/java/org/YanPl/api/StreamingHandler.java
+++ b/src/main/java/org/YanPl/api/StreamingHandler.java
@@ -369,6 +369,20 @@ public class StreamingHandler {
                                 }
                             }
                         }
+                        // 捕获 Gemma 等模型的 reasoning 字段（CloudFlare Workers AI 兼容格式）
+                        if (delta.has("reasoning") && !delta.get("reasoning").isJsonNull()) {
+                            String rc = delta.get("reasoning").getAsString();
+                            if (!rc.isEmpty()) {
+                                hasReasoningInChunk = true;
+                                if (reasoningStartTime == -1) {
+                                    reasoningStartTime = System.currentTimeMillis();
+                                }
+                                thoughtContent.append(rc);
+                                if (onReasoningCallback != null) {
+                                    try { onReasoningCallback.accept(rc); } catch (Exception ignored) {}
+                                }
+                            }
+                        }
                     }
                     if (choice.has("text") && !choice.get("text").isJsonNull()) {
                         return choice.get("text").getAsString();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,7 @@ provider: cloudflare
 # CloudFlare Workers AI 配置
 cloudflare:
   # CloudFlare Workers AI API 密钥，FancyHelper会自动根据密钥来获取对应的account-id
+  # 如果你有疑问，可以看看 https://blog.baicaizhale.top/post/create-cf-key-for-fhai
   cf_key: "maF_cBg4UXnWgTaE8t8tdAq-iGZ5osv6CHxm2nH0"
   # 使用的模型名称，不推荐更改，可以是任何一个Text-Generation模型
   model: "@cf/google/gemma-4-26b-a4b-it"


### PR DESCRIPTION
## 修复了什么

### Gemma 系列模型的思考过程现在可以显示了
之前使用 Gemma 4 等模型时，模型的思考内容（reasoning）在流式输出时会被跳过，导致思考过程完全不可见。现在已修复，思考内容会正常渲染。

### 部分 CloudFlare 模型流式模式卡住无响应
发现 @cf/openai/gpt-oss-120b 等特定模型在流式模式下会卡住，屏幕上一直显示 0 tokens。这类模型现在会自动改用非流式请求，虽然失去逐字输出效果，但能正常返回结果了。

### 不影响
- 其他 CloudFlare 模型（如 Kimi K2.5、Qwen 等）不受影响
- OpenAI 兼容 API 不受影响
- 非流式模式不受影响