### PR TITLE
fix: 修复 CLI 模式下聊天消息被 TrChat 泄漏到公共频道

### DIFF
--- a/src/main/java/org/YanPl/listener/ChatListener.java
+++ b/src/main/java/org/YanPl/listener/ChatListener.java
@@ -81,8 +81,11 @@ public class ChatListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
-        if (paperChatEventExists) return;
-        
+        // 即使 paperChatEventExists 为 true（Paper 服务端），也要处理 Bukkit 事件，
+        // 因为 TrChat 等聊天插件可能监听 Bukkit 的 AsyncPlayerChatEvent，
+        // 而 Paper 为了兼容性会同时触发 Bukkit 事件。
+        // 如果只处理 Paper 的 AsyncChatEvent，Bukkit 事件仍会被其他插件收到并广播。
+
         String message = event.getMessage();
         Player player = event.getPlayer();
         if (!plugin.getCliManager().handleChat(player, message)) {
@@ -140,6 +143,13 @@ public class ChatListener implements Listener {
                             }
                             return;
                         }
+                        // 清空消息内容，防止 TrChat 等插件在 HIGHEST 优先级（ignoreCancelled=true）
+                        // 仍然读取并广播原始消息
+                        Class<?> componentClass = Class.forName("net.kyori.adventure.text.Component");
+                        Method emptyMethod = componentClass.getMethod("empty");
+                        Object emptyComponent = emptyMethod.invoke(null);
+                        Method setMessageMethod = event.getClass().getMethod("message", componentClass);
+                        setMessageMethod.invoke(event, emptyComponent);
                         try {
                             Method setCancelledMethod = event.getClass().getMethod("setCancelled", boolean.class);
                             setCancelledMethod.invoke(event, true);


### PR DESCRIPTION
## 问题

Paper/Purpur 服务端上，玩家在 CLI 模式下输入的消息会被 TrChat 广播到公共频道，
导致其他玩家看到 CLI 输入内容。

## 根因

TrChat 的 `onPaperChat` 以 `EventPriority.HIGHEST` + `ignoreCancelled=true` 注册
Paper `AsyncChatEvent`，即使 FancyHelper 在 `LOWEST` 取消事件，TrChat 无视取消状态，
仍通过 `e.message().toNative()` 读取原始消息内容并用 `channel.execute()` 广播。

## 修复

1. **Paper `AsyncChatEvent` handler**：拦截 CLI 消息时将事件内容置为 `Component.empty()`，
   确保 FancyHelper（`LOWEST`，先执行）修改后，TrChat（`HIGHEST`，后执行）读到的是空内容
2. **Bukkit `AsyncPlayerChatEvent` handler**：移除 `if (paperChatEventExists) return;`
   的 early return，防止其他监听 Bukkit 事件的插件泄漏消息

## 测试

- [x] Purpur 1.21 + FancyHelper + TrChat，CLI 模式下输入不出现于公共频道
- [x] 非 CLI 玩家正常聊天不受影响
- [x] CLI 玩家 `!消息` 转义发送正常