### PR TITLE
fix: 修复 ReloadService 热更新 & Skill 更新检测

### DIFF
--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -672,6 +672,7 @@ public final class FancyHelper extends JavaPlugin {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void cleanupServerPluginProviderStorage(Object paperPluginManager, String pluginName) {
         try {
             Field entrypointHandlerField = paperPluginManager.getClass().getDeclaredField("entrypointHandler");

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -345,10 +345,6 @@ public class ConfigManager {
         return config.getBoolean("settings.auto_upgrade", false);
     }
 
-    public String getUpdateMirror() {
-        return config.getString("settings.update_mirror", "https://gh-proxy.com/");
-    }
-
     /**
      * 获取 Skill 远程仓库地址
      */

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -346,7 +346,7 @@ public class ConfigManager {
     }
 
     public String getUpdateMirror() {
-        return config.getString("settings.update_mirror", "https://ghproxy.net/");
+        return config.getString("settings.update_mirror", "https://gh-proxy.com/");
     }
 
     /**
@@ -360,7 +360,7 @@ public class ConfigManager {
      * 获取 Skill 下载镜像源
      */
     public String getSkillUpdateMirror() {
-        return config.getString("settings.skill_update_mirror", "https://ghproxy.net/");
+        return config.getString("settings.skill_update_mirror", "https://gh-proxy.com/");
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/SkillLoader.java
+++ b/src/main/java/org/YanPl/manager/SkillLoader.java
@@ -39,8 +39,8 @@ public class SkillLoader {
     public List<Skill> loadAllSkills() {
         List<Skill> skills = new ArrayList<>();
 
-        // 释放内置 Skill 资源（覆盖旧文件以确保 source 等字段最新）
-        ResourceUtil.releaseResources(plugin, "skills/", true, ".md");
+        // 释放内置 Skill 资源（不覆盖已存在的文件，避免覆盖远程下载的新版本）
+        ResourceUtil.releaseResources(plugin, "skills/", false, ".md");
 
         // 从 skillsDir 递归加载所有 Skill
         skills.addAll(loadFromDirectory(skillsDir, false, false));

--- a/src/main/java/org/YanPl/manager/SkillLoader.java
+++ b/src/main/java/org/YanPl/manager/SkillLoader.java
@@ -39,8 +39,8 @@ public class SkillLoader {
     public List<Skill> loadAllSkills() {
         List<Skill> skills = new ArrayList<>();
 
-        // 释放内置 Skill 资源（不覆盖已存在的文件）
-        ResourceUtil.releaseResources(plugin, "skills/", false, ".md");
+        // 释放内置 Skill 资源（覆盖旧文件以确保 source 等字段最新）
+        ResourceUtil.releaseResources(plugin, "skills/", true, ".md");
 
         // 从 skillsDir 递归加载所有 Skill
         skills.addAll(loadFromDirectory(skillsDir, false, false));

--- a/src/main/java/org/YanPl/manager/SkillUpdateManager.java
+++ b/src/main/java/org/YanPl/manager/SkillUpdateManager.java
@@ -139,23 +139,14 @@ public class SkillUpdateManager implements Listener {
         hasUpdates = false;
 
         try {
-            String manifestUrl = getManifestUrl();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(manifestUrl))
-                    .header("User-Agent", "FancyHelper-SkillUpdater")
-                    .timeout(Duration.ofSeconds(15))
-                    .GET()
-                    .build();
-
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() != 200) {
-                notify(sender, "§c获取 Skill 更新清单失败 (HTTP " + response.statusCode() + ")");
-                plugin.getLogger().warning("[SkillUpdate] 获取 manifest 失败: HTTP " + response.statusCode());
+            String body = fetchWithFallback(getManifestUrl(), plugin.getConfigManager().getSkillRepoBase() + "manifest.json");
+            if (body == null) {
+                notify(sender, "§c获取 Skill 更新清单失败");
+                plugin.getLogger().warning("[SkillUpdate] 获取 manifest 失败（镜像+直连均不可用）");
                 return;
             }
 
-            JsonObject manifest = JsonParser.parseString(response.body()).getAsJsonObject();
+            JsonObject manifest = JsonParser.parseString(body).getAsJsonObject();
             if (!manifest.has("skills")) {
                 notify(sender, "§cSkill 更新清单格式错误");
                 return;
@@ -211,13 +202,6 @@ public class SkillUpdateManager implements Listener {
                 plugin.getLogger().info("[SkillUpdate] 所有 Skill 已是最新 (" + checkedCount + " 个检查)");
             }
 
-        } catch (IOException e) {
-            plugin.getLogger().warning("[SkillUpdate] 检查更新失败: " + e.getMessage());
-            notify(sender, "§c检查 Skill 更新失败: " + e.getMessage());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            plugin.getLogger().warning("[SkillUpdate] 检查更新被中断");
-            notify(sender, "§c检查 Skill 更新被中断");
         } finally {
             checking = false;
         }
@@ -261,21 +245,16 @@ public class SkillUpdateManager implements Listener {
      * 下载单个 Skill 文件到 skills 目录
      */
     private boolean downloadSkillFile(String skillId) {
-        String fileUrl = getSkillFileUrl(skillId);
+        String mirrorUrl = getSkillFileUrl(skillId);
+        String directUrl = plugin.getConfigManager().getSkillRepoBase() + skillId + "/skill.md";
         SkillLoader loader = skillManager.getLoader();
 
         try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(fileUrl))
-                    .header("User-Agent", "FancyHelper-SkillUpdater")
-                    .timeout(Duration.ofSeconds(30))
-                    .GET()
-                    .build();
-
-            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-
-            if (response.statusCode() != 200) {
-                plugin.getLogger().warning("[SkillUpdate] 下载 " + skillId + " 失败: HTTP " + response.statusCode());
+            // 优先镜像，失败回退直连
+            HttpResponse<InputStream> response = fetchInputStreamWithFallback(mirrorUrl, directUrl);
+            if (response == null || response.statusCode() != 200) {
+                int code = response != null ? response.statusCode() : 0;
+                plugin.getLogger().warning("[SkillUpdate] 下载 " + skillId + " 失败: HTTP " + code);
                 return false;
             }
 
@@ -292,10 +271,7 @@ public class SkillUpdateManager implements Listener {
 
             return true;
 
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (IOException e) {
             plugin.getLogger().warning("[SkillUpdate] 下载 " + skillId + " 失败: " + e.getMessage());
             return false;
         }
@@ -344,6 +320,76 @@ public class SkillUpdateManager implements Listener {
     private String getJsonString(JsonObject obj, String key) {
         if (obj.has(key) && !obj.get(key).isJsonNull()) {
             return obj.get(key).getAsString();
+        }
+        return null;
+    }
+
+    /**
+     * 请求 URL 获取文本，优先走镜像，失败回退直连。
+     * @return 响应体，失败返回 null
+     */
+    private String fetchWithFallback(String mirrorUrl, String directUrl) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(mirrorUrl))
+                    .header("User-Agent", "FancyHelper-SkillUpdater")
+                    .timeout(Duration.ofSeconds(15))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) return response.body();
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+        }
+        // 回退直连
+        try {
+            plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连...");
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(directUrl))
+                    .header("User-Agent", "FancyHelper-SkillUpdater")
+                    .timeout(Duration.ofSeconds(15))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) return response.body();
+            plugin.getLogger().warning("[SkillUpdate] 直连返回 HTTP " + response.statusCode());
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            plugin.getLogger().warning("[SkillUpdate] 直连请求失败: " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * 请求 URL 获取输入流，优先走镜像，失败回退直连。
+     * @return 响应，失败返回 null
+     */
+    private HttpResponse<InputStream> fetchInputStreamWithFallback(String mirrorUrl, String directUrl) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(mirrorUrl))
+                    .header("User-Agent", "FancyHelper-SkillUpdater")
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() == 200) return response;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+        }
+        // 回退直连
+        try {
+            plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连下载...");
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(directUrl))
+                    .header("User-Agent", "FancyHelper-SkillUpdater")
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() == 200) return response;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
         }
         return null;
     }

--- a/src/main/java/org/YanPl/manager/SkillUpdateManager.java
+++ b/src/main/java/org/YanPl/manager/SkillUpdateManager.java
@@ -152,26 +152,28 @@ public class SkillUpdateManager implements Listener {
                 return;
             }
 
-            JsonObject skills = manifest.getAsJsonObject("skills");
+            JsonObject skillsObj = manifest.getAsJsonObject("skills");
             List<Skill> localUpdatable = skillManager.getRegistry().getUpdatableSkills();
 
             int checkedCount = 0;
 
             for (Skill localSkill : localUpdatable) {
                 String id = localSkill.getId();
-                if (!skills.has(id)) continue;
+                if (!skillsObj.has(id)) continue;
 
-                JsonObject remoteSkill = skills.getAsJsonObject(id);
+                JsonObject remoteSkill = skillsObj.getAsJsonObject(id);
                 String remoteVersion = getJsonString(remoteSkill, "version");
+                String localVersion = localSkill.getMetadata().getVersion();
 
-                if (remoteVersion != null && isNewerVersion(localSkill.getMetadata().getVersion(), remoteVersion)) {
+                // 只要版本不同就更新，不比较高低
+                if (remoteVersion != null && !remoteVersion.equals(localVersion)) {
                     pendingUpdates.put(id, remoteVersion);
                 }
                 checkedCount++;
             }
 
             // 本地没有但远端有的技能（新技能）
-            for (Map.Entry<String, JsonElement> entry : skills.entrySet()) {
+            for (Map.Entry<String, JsonElement> entry : skillsObj.entrySet()) {
                 String id = entry.getKey();
                 if (!skillManager.hasSkill(id)) {
                     JsonObject remoteSkill = entry.getValue().getAsJsonObject();
@@ -292,28 +294,6 @@ public class SkillUpdateManager implements Listener {
     private void notify(Player player, String text) {
         if (player != null) {
             player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper §7> §f" + text));
-        }
-    }
-
-    private boolean isNewerVersion(String current, String latest) {
-        if (current == null || latest == null) return false;
-        String[] currentParts = current.split("\\.");
-        String[] latestParts = latest.split("\\.");
-        int length = Math.max(currentParts.length, latestParts.length);
-        for (int i = 0; i < length; i++) {
-            int curr = i < currentParts.length ? parseVersionPart(currentParts[i]) : 0;
-            int late = i < latestParts.length ? parseVersionPart(latestParts[i]) : 0;
-            if (late > curr) return true;
-            if (late < curr) return false;
-        }
-        return false;
-    }
-
-    private int parseVersionPart(String part) {
-        try {
-            return Integer.parseInt(part.replaceAll("[^0-9]", ""));
-        } catch (NumberFormatException e) {
-            return 0;
         }
     }
 

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -64,14 +64,19 @@ public class UpdateManager implements Listener {
                     .build();
 
             try {
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(repoUrl))
-                        .header("User-Agent", "FancyHelper-Updater")
-                        .timeout(Duration.ofSeconds(10))
-                        .GET()
-                        .build();
-
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                // 优先通过镜像代理 API 请求，避免 GitHub 频率限制
+                String mirror = "https://gh-proxy.com/";
+                HttpResponse<String> response;
+                try {
+                    response = fetchApiResponse(client, mirror + repoUrl);
+                } catch (IOException e) {
+                    plugin.getLogger().info("镜像代理连接失败 (" + e.getMessage() + ")，尝试直连...");
+                    response = fetchApiResponse(client, repoUrl);
+                }
+                if (response.statusCode() != 200) {
+                    plugin.getLogger().info("镜像代理 API 返回 " + response.statusCode() + "，回退直连...");
+                    response = fetchApiResponse(client, repoUrl);
+                }
 
                 if (response.statusCode() == 200) {
                     String jsonResponse = response.body();
@@ -235,7 +240,7 @@ public class UpdateManager implements Listener {
         if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f开始下载更新..."));
 
         Runnable downloadTask = () -> {
-            String mirror = plugin.getConfigManager().getUpdateMirror();
+            String mirror = "https://gh-proxy.com/";
             String finalUrl = mirror + downloadUrl;
 
             if (plugin.getConfigManager().isDebug()) {
@@ -433,5 +438,15 @@ public class UpdateManager implements Listener {
                 player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。"));
             }, 40L); // 延迟 2 秒提示
         }
+    }
+
+    private HttpResponse<String> fetchApiResponse(HttpClient client, String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("User-Agent", "FancyHelper-Updater")
+                .timeout(Duration.ofSeconds(10))
+                .GET()
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
     }
 }

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -392,27 +392,35 @@ public class UpdateManager implements Listener {
      */
     private boolean isNewerVersion(String current, String latest) {
         if (current == null || latest == null) return false;
-
-        String[] currentParts = current.split("\\.");
-        String[] latestParts = latest.split("\\.");
-
-        int length = Math.max(currentParts.length, latestParts.length);
-        for (int i = 0; i < length; i++) {
-            int curr = i < currentParts.length ? parseVersionPart(currentParts[i]) : 0;
-            int late = i < latestParts.length ? parseVersionPart(latestParts[i]) : 0;
-
-            if (late > curr) return true;
-            if (late < curr) return false;
-        }
-        return false;
+        return compareVersion(current, latest) < 0;
     }
 
-    private int parseVersionPart(String part) {
-        try {
-            return Integer.parseInt(part.replaceAll("[^0-9]", ""));
-        } catch (NumberFormatException e) {
-            return 0;
+    private int compareVersion(String v1, String v2) {
+        String[] p1 = v1.trim().split("\\.");
+        String[] p2 = v2.trim().split("\\.");
+        int len = Math.max(p1.length, p2.length);
+        for (int i = 0; i < len; i++) {
+            int n1 = i < p1.length ? toInt(p1[i]) : 0;
+            int n2 = i < p2.length ? toInt(p2[i]) : 0;
+            if (n1 != n2) return n1 - n2;
         }
+        return 0;
+    }
+
+    private int toInt(String s) {
+        if (s == null || s.isEmpty()) return 0;
+        int num = 0;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c >= '0' && c <= '9') {
+                num = num * 10 + (c - '0');
+            } else if (i == 0) {
+                continue;
+            } else {
+                break;
+            }
+        }
+        return num;
     }
 
     @EventHandler

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -181,11 +181,14 @@ public class UpdateManager implements Listener {
                         }
                     }
                 } else {
-                    String responseBody = response.body();
-                    plugin.getLogger().warning("检查更新失败 - HTTP " + response.statusCode() + ": " + (responseBody.length() > 200 ? responseBody.substring(0, 200) + "..." : responseBody));
-                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败（HTTP " + response.statusCode() + "）。"));
+                    int code = response.statusCode();
+                    if (code == 403 || code == 429) {
+                        plugin.getLogger().info("GitHub API 访问受限（频率限制），跳过本次更新检查");
+                    } else {
+                        plugin.getLogger().warning("检查更新失败 - HTTP " + code);
+                    }
                     if (sender != null) {
-                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败（HTTP " + response.statusCode() + "）。"));
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败（HTTP " + code + "）。"));
                     }
                 }
             } catch (IOException e) {

--- a/src/main/java/org/YanPl/model/Skill.java
+++ b/src/main/java/org/YanPl/model/Skill.java
@@ -15,7 +15,7 @@ public class Skill {
 
     // Front Matter 分隔符正则
     private static final Pattern FRONT_MATTER_PATTERN =
-            Pattern.compile("^---\\s*\\r?\\n(.*?)\\r?\\n---\\s*\\r?\\n(.*)", Pattern.DOTALL);
+            Pattern.compile("^---\\s*\\R(.*?)\\R---", Pattern.DOTALL);
 
     private final String id;
     private final SkillMetadata metadata;
@@ -75,19 +75,27 @@ public class Skill {
 
         Matcher matcher = FRONT_MATTER_PATTERN.matcher(fullContent);
 
-        if (matcher.find()) {
-            String yamlPart = matcher.group(1);
-            String markdownPart = matcher.group(2);
+        SkillMetadata metadata;
+        String content;
 
-            SkillMetadata metadata = SkillMetadata.fromYaml(yamlPart);
-            return new Skill(id, metadata, markdownPart.trim(), fullContent, sourceFile, isRemote, isBuiltIn);
+        if (matcher.find()) {
+            String yamlRaw = matcher.group(1);
+            metadata = SkillMetadata.fromYaml(yamlRaw);
+            content = fullContent.substring(matcher.end()).trim();
         } else {
-            // 无 Front Matter，创建默认元数据
-            SkillMetadata metadata = new SkillMetadata();
+            metadata = new SkillMetadata();
             metadata.setName(id);
             metadata.setDescription("No description provided");
-            return new Skill(id, metadata, fullContent.trim(), fullContent, sourceFile, isRemote, isBuiltIn);
+            metadata.setVersion("0");
+            content = fullContent.trim();
         }
+
+        // 如果 source 未设置，用 skill ID（目录名）兜底 — 两个分支通用
+        if (metadata.getSource() == null || metadata.getSource().isEmpty()) {
+            metadata.setSource(id);
+        }
+
+        return new Skill(id, metadata, content, fullContent, sourceFile, isRemote, isBuiltIn);
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,8 +29,6 @@ settings:
   op_update_notify: true
   # 是否在检测到新版本时自动下载并安装更新，Paper及下游服务端推荐开启（使用Spigot及上游服务端请关闭此选项，目前还是会出bug）
   auto_upgrade: true
-  # GitHub 镜像源，用于加速下载
-  update_mirror: "https://gh-proxy.com/"
   # Skill 远程仓库地址
   skill_repo_base: "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/"
   # Skill 下载镜像源

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,11 +30,11 @@ settings:
   # 是否在检测到新版本时自动下载并安装更新，Paper及下游服务端推荐开启（使用Spigot及上游服务端请关闭此选项，目前还是会出bug）
   auto_upgrade: true
   # GitHub 镜像源，用于加速下载
-  update_mirror: "https://ghproxy.net/"
+  update_mirror: "https://gh-proxy.com/"
   # Skill 远程仓库地址
   skill_repo_base: "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/"
   # Skill 下载镜像源
-  skill_update_mirror: "https://ghproxy.net/"  
+  skill_update_mirror: "https://gh-proxy.com/"  
   # 防循环检测的连续相似调用阈值
   anti_loop:
     # 连续多少次相似调用触发中断

--- a/src/test/java/org/YanPl/manager/ConfigManagerTest.java
+++ b/src/test/java/org/YanPl/manager/ConfigManagerTest.java
@@ -223,17 +223,6 @@ class ConfigManagerTest {
     }
 
     @Test
-    @DisplayName("getUpdateMirror 应返回配置值")
-    void testGetUpdateMirror_ReturnsConfigValue() {
-        when(config.getString("settings.update_mirror", "https://gh-proxy.com/"))
-            .thenReturn("https://custom.mirror/");
-
-        String result = configManager.getUpdateMirror();
-
-        assertEquals("https://custom.mirror/", result);
-    }
-
-    @Test
     @DisplayName("getAntiLoopThresholdCount 应返回配置值")
     void testGetAntiLoopThresholdCount_ReturnsConfigValue() {
         when(config.getInt("settings.anti_loop.threshold_count", 3)).thenReturn(5);
@@ -448,17 +437,6 @@ class ConfigManagerTest {
         boolean result = configManager.isToolEnabled("unknown");
 
         assertFalse(result);
-    }
-
-    @Test
-    @DisplayName("getUpdateMirror 默认值")
-    void testGetUpdateMirror_DefaultValue() {
-        when(config.getString("settings.update_mirror", "https://gh-proxy.com/"))
-            .thenReturn("https://gh-proxy.com/");
-
-        String result = configManager.getUpdateMirror();
-
-        assertEquals("https://gh-proxy.com/", result);
     }
 
     @Test

--- a/src/test/java/org/YanPl/manager/ConfigManagerTest.java
+++ b/src/test/java/org/YanPl/manager/ConfigManagerTest.java
@@ -225,7 +225,7 @@ class ConfigManagerTest {
     @Test
     @DisplayName("getUpdateMirror 应返回配置值")
     void testGetUpdateMirror_ReturnsConfigValue() {
-        when(config.getString("settings.update_mirror", "https://ghproxy.net/"))
+        when(config.getString("settings.update_mirror", "https://gh-proxy.com/"))
             .thenReturn("https://custom.mirror/");
 
         String result = configManager.getUpdateMirror();
@@ -453,12 +453,12 @@ class ConfigManagerTest {
     @Test
     @DisplayName("getUpdateMirror 默认值")
     void testGetUpdateMirror_DefaultValue() {
-        when(config.getString("settings.update_mirror", "https://ghproxy.net/"))
-            .thenReturn("https://ghproxy.net/");
+        when(config.getString("settings.update_mirror", "https://gh-proxy.com/"))
+            .thenReturn("https://gh-proxy.com/");
 
         String result = configManager.getUpdateMirror();
 
-        assertEquals("https://ghproxy.net/", result);
+        assertEquals("https://gh-proxy.com/", result);
     }
 
     @Test


### PR DESCRIPTION
## Summary

### ReloadService 热更新
- JAR 文件被 JVM 锁定导致删除失败：改用 `delete()` 返回值检测，失败则延迟重试
- `onDisable()` 增加 Paper 插件注册表清理，修复 `plm reload` 报 duplicate plugin identifier

### Skill 更新检测（三重根因）
1. **正则 `\r?\n` 不兼容**：`FRONT_MATTER_PATTERN` 对 JAR 释放的文件在 Windows/Paper 上匹配失败，改用 `\R`
2. **`else` 分支 version 默认值陷阱**：无 Front Matter 时 version 默认 `1.0.0` 与远程一致，静默跳过更新
3. **`source` 兜底只覆盖 `if` 分支**：提到 if/else 之外，两条路径通用

### 版本比对简化
- Skill 版本比对从 `isNewerVersion` 改为 `!equals`，只要不同就更新
- `replace=true` 会导致远程下载的新版被 JAR 内置旧版覆盖，改为 `false`

### HTTP 请求健壮性
- GitHub API 版本检查走 gh-proxy.com 代理，绕过匿名频率限制
- 镜像不可用时自动回退直连
- 403/429 降级为 INFO 不再打印大段 JSON

## Test plan
- [ ] `cli reload deeply` → 自动检测并下载 Skill 更新
- [ ] `cli skill checkupdate` → 确认非"0 个检查"
- [ ] `plm reload fancyhelper` → 确认无 duplicate plugin identifier 错误
- [ ] 检查更新日志不再出现 HTTP 403 大段 JSON