### PR TITLE
ui: 优化确认按钮样式，Y/N 方括号替换为 ✔/✘ 无边框符号

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1333,13 +1333,13 @@ public class CLIManager {
             player.sendMessage(ChatColor.DARK_GRAY + "─────────────────────────────");
             player.sendMessage(ChatColor.WHITE + "进入 Plan Mode 前，是否清空上下文？");
 
-            TextComponent yBtn = new TextComponent(ChatColor.GREEN + "[ Y ] 清空");
+            TextComponent yBtn = new TextComponent(ChatColor.GREEN + "✔ 清空");
             yBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_clear_y"));
             yBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("清空对话历史后进入 Plan Mode")));
 
             TextComponent spacer = new TextComponent("  ");
 
-            TextComponent nBtn = new TextComponent(ChatColor.RED + "[ N ] 保留");
+            TextComponent nBtn = new TextComponent(ChatColor.RED + "✘ 保留");
             nBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli plan_clear_n"));
             nBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("保留对话历史并进入 Plan Mode")));
 

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -420,15 +420,15 @@ public class ToolExecutor {
      */
     public void sendConfirmButtons(Player player, String displayAction) {
         TextComponent message = new TextComponent(displayAction != null && !displayAction.trim().isEmpty() 
-            ? (ChatColor.GRAY + ">> " + ChatColor.WHITE + displayAction + " ") : "");
+            ? (ChatColor.GRAY + ">> " + ChatColor.WHITE + displayAction + "   ") : "");
 
-        TextComponent yBtn = new TextComponent(ChatColor.GREEN + "[ Y ]");
+        TextComponent yBtn = new TextComponent(ChatColor.GREEN + "✔");
         yBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli confirm"));
         yBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("确认执行操作")));
 
         TextComponent spacer = new TextComponent(" / ");
 
-        TextComponent nBtn = new TextComponent(ChatColor.RED + "[ N ]");
+        TextComponent nBtn = new TextComponent(ChatColor.RED + "✘");
         nBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli cancel"));
         nBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("取消执行")));
 


### PR DESCRIPTION
## Summary
- 将 [#run] / [#edit] 确认按钮从 `[ Y ] / [ N ]` 改为 `✔ / ✘` 无边框符号
- Plan 模式清空上下文按钮同步改为 `✔ 清空 / ✘ 保留`
- 按钮与命令文本间距调整为 3 空格

## Before / After
```
Before:  >> /say hello [ Y ] / [ N ]
After:   >> /say hello   ✔ / ✘
```