### PR TITLE
fix: 流式输出下思考按钮展示错误思考内容

### DIFF
--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -2153,7 +2153,8 @@ public class CLIManager {
         
         StreamingHandler streamingHandler = new StreamingHandler(plugin, player);
         activeStreamingHandlers.put(uuid, streamingHandler);
-        
+        final long reservedMessageId = session.getNextMessageId();
+
         final StringBuilder fullResponseText = new StringBuilder();
         final StringBuilder accumulatedText = new StringBuilder();
         final String[] lastFormatted = {""};
@@ -2174,7 +2175,7 @@ public class CLIManager {
                 session.addThinkingTime(thinkingTimeMs);
 
                 TextComponent thoughtBtn = new TextComponent(ChatColor.GRAY + " ※ Thought");
-                thoughtBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli thought"));
+                thoughtBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli thought t:" + reservedMessageId));
                 thoughtBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "点击查看本次思考过程")));
                 double sec = thinkingTimeMs / 1000.0;
                 TextComponent timeTag = new TextComponent(ChatColor.DARK_GRAY + " (" + String.format("%.1f", sec) + "s)");

--- a/src/main/java/org/YanPl/model/DialogueSession.java
+++ b/src/main/java/org/YanPl/model/DialogueSession.java
@@ -507,6 +507,10 @@ public class DialogueSession {
         this.lastThought = lastThought;
     }
 
+    public long getNextMessageId() {
+        return nextMessageId;
+    }
+
     public String getLastError() {
         return lastError;
     }


### PR DESCRIPTION
## Summary
- 流式输出下创建思考按钮时预读 messageId，嵌入 `/cli thought t:<id>` 命令
- 点击旧按钮时通过 messageId 精确命中对应思考快照，不再回退到被覆盖的 `lastThought`

## Root Cause
`onReasoningCompleteCallback` 创建按钮时消息尚未入 history，无法获取 messageId，只能用 `/cli thought` 裸命令。点击时 `handleThought` 回退到 `session.getLastThought()`，该值已后续响应覆盖。

## Test plan
- [ ] 编译通过
- [ ] 流式输出下发送两条需要思考的问题
- [ ] 点击第一条的思考按钮，确认展示第一条的思考内容