### PR TITLE
fix: 管理员进服自动检查 Skill 更新时无更新不再发消息

### DIFF
--- a/src/main/java/org/YanPl/manager/SkillUpdateManager.java
+++ b/src/main/java/org/YanPl/manager/SkillUpdateManager.java
@@ -193,9 +193,8 @@ public class SkillUpdateManager implements Listener {
                         String localVer = local != null ? local.getMetadata().getVersion() : "未安装";
                         sender.sendMessage(" §7- §b" + entry.getKey() + " §7" + localVer + " §7→ §a" + entry.getValue());
                     }
-                } else {
-                    sender.sendMessage(msg("所有 Skill 已是最新版本"));
                 }
+                // 无更新时不发送消息，避免打扰
             }
 
             if (hasUpdates) {


### PR DESCRIPTION
## Summary

- 管理员进服时自动检查 Skill 更新，若无更新不再发送"所有 Skill 已是最新版本"聊天消息
- 减少员无关冗余通知，服务端日志仍保留以便排查

## Changes

- `SkillUpdateManager.java`: 移除无更新时向玩家发送的 `else` 分支，保留服务端日志

## Test plan

- [ ] 以管理员身份进服，有更新时正常提示
- [ ] 以管理员身份进服，无更新时不弹消息