### PR TITLE
feat: 拦截 CLI 模式下误输 /stop 和 /exit 命令

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -118,6 +118,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "menu":
             case "retry":
             case "stop":
+            case "exit":
             case "memory":
             case "mem":
             case "smart_allow":
@@ -175,6 +176,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(" §7- §b/cli normal §f: 切换到普通模式（需要确认）");
         sender.sendMessage(" §7- §b/cli retry §f: 重试上一次失败的 AI 调用");
         sender.sendMessage(" §7- §b/cli stop §f: 停止当前 AI 对话");
+        sender.sendMessage(" §7- §b/cli exit §f: 退出 CLI 模式");
         sender.sendMessage(" §7- §b/cli compress §f: 使用AI智能压缩当前会话上下文");
         sender.sendMessage(" §7- §b/cli streaming §f: 切换流式输出开关");
         sender.sendMessage(" §7- §b/cli skill §f: Skill 管理命令");
@@ -289,6 +291,9 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 return true;
             case "stop":
                 plugin.getCliManager().handleChat(player, "stop");
+                return true;
+            case "exit":
+                plugin.getCliManager().exitCLI(player);
                 return true;
             case "todo":
                 plugin.getCliManager().openTodoBook(player);
@@ -1037,7 +1042,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 "read", "set", "settings", "tools", "display", "streaming", "toggle",
                 "notice", "retry", "todo", "memory", "mem", "confirm",
                 "cancel", "agree", "thought", "select", "exempt_anti_loop",
-                "stop", "download", "help", "lib", "compress", "skill"
+                "stop", "exit", "download", "help", "lib", "compress", "skill"
             ));
             return subCommands.stream()
                     .filter(s -> s.startsWith(args[0].toLowerCase()))

--- a/src/main/java/org/YanPl/listener/ChatListener.java
+++ b/src/main/java/org/YanPl/listener/ChatListener.java
@@ -1,12 +1,18 @@
 package org.YanPl.listener;
 
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.YanPl.FancyHelper;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
@@ -100,6 +106,31 @@ public class ChatListener implements Listener {
         }
         event.getRecipients().clear();
         event.setCancelled(true);
+    }
+
+    /**
+     * 拦截 CLI 模式下玩家误输 /stop 和 /exit 等命令
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        Player player = event.getPlayer();
+        if (!plugin.getCliManager().isInCLI(player)) return;
+
+        String cmd = event.getMessage().toLowerCase().split(" ")[0];
+
+        if (cmd.equals("/stop")) {
+            event.setCancelled(true);
+            player.sendMessage(ChatColor.YELLOW + "⚡ 检测到 /stop，是否想输入 stop 打断 AI？已为你执行打断。");
+            plugin.getCliManager().handleChat(player, "stop");
+        } else if (cmd.equals("/exit")) {
+            event.setCancelled(true);
+            TextComponent msg = new TextComponent(ChatColor.GRAY + "你是否想退出 CLI 模式？ ");
+            TextComponent escapeBtn = new TextComponent(ChatColor.GOLD + "" + ChatColor.BOLD + "[ Escape ]");
+            escapeBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli exit"));
+            escapeBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text("点击退出 CLI 模式")));
+            msg.addExtra(escapeBtn);
+            player.spigot().sendMessage(msg);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- 玩家在 CLI 模式下误输 `/stop` 时拦截并提醒，自动执行 AI 打断
- 误输 `/exit` 时提示并展示橙色 `[Escape]` 可点击按钮退出 CLI 模式
- 新增 `/cli exit` 子命令

## Changes

- `ChatListener.java` — 新增 `PlayerCommandPreprocessEvent` 监听器拦截 `/stop` 和 `/exit`
- `CLICommand.java` — 注册 `/cli exit` 子命令、Tab 补全、帮助文本

## Test plan

- [x] CLI 模式下输入 `/stop`，应拦截并打断 AI
- [x] CLI 模式下输入 `/exit`，应拦截并显示 `[Escape]` 按钮
- [ ] 点击 `[Escape]` 应退出 CLI 模式
- [ ] 非 CLI 模式下 `/stop` 和 `/exit` 行为不受影响