### PR TITLE
feat: bStats 自定义统计 — Token消耗 / CLI进入 / 对话次数

### DIFF
--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -18,6 +18,7 @@ import org.YanPl.manager.InstructionManager;
 import org.YanPl.manager.GuiManager;
 import org.YanPl.manager.SkillManager;
 import org.YanPl.manager.SkillUpdateManager;
+import org.YanPl.manager.StatsManager;
 import org.YanPl.util.CloudErrorReport;
 import org.YanPl.util.ErrorHandler;
 import org.bstats.bukkit.Metrics;
@@ -56,6 +57,7 @@ public final class FancyHelper extends JavaPlugin {
     private GuiManager guiManager;
     private SkillManager skillManager;
     private SkillUpdateManager skillUpdateManager;
+    private StatsManager statsManager;
 
     @Override
     public void onEnable() {
@@ -145,7 +147,8 @@ public final class FancyHelper extends JavaPlugin {
 
             // bStats 统计
             int pluginId = 29036;
-            new Metrics(this, pluginId);
+            Metrics metrics = new Metrics(this, pluginId);
+            statsManager = new StatsManager(this, metrics);
 
             // 检查 server.properties 中的安全配置并提示
             checkSecureProfile();
@@ -409,6 +412,11 @@ public final class FancyHelper extends JavaPlugin {
             instructionManager.shutdown();
         }
 
+        // 保存统计数据
+        if (statsManager != null) {
+            statsManager.save();
+        }
+
         // 等待短暂时间以确保后台任务结束
         try {
             Thread.sleep(500);
@@ -485,6 +493,10 @@ public final class FancyHelper extends JavaPlugin {
 
     public SkillUpdateManager getSkillUpdateManager() {
         return skillUpdateManager;
+    }
+
+    public StatsManager getStatsManager() {
+        return statsManager;
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1058,6 +1058,7 @@ public class CLIManager {
         }
         
         activeCLIPayers.add(uuid);
+        plugin.getStatsManager().incrementCliEntry();
         // 注意：新会话已经在上面放入 Map，这里只处理恢复会话的情况
         if (session != null) {
             sessions.put(uuid, session);
@@ -1165,6 +1166,11 @@ public class CLIManager {
             if (pendingStreamed != null && pendingStreamed > 0) {
                 exitSession.addOutputTokens(pendingStreamed);
                 roundOutputTokens.merge(uuid, pendingStreamed, (a, b) -> a + b);
+            }
+            // 将本次会话的总 token 汇入全局统计
+            long sessionTotal = exitSession.getTotalInputTokens() + exitSession.getTotalOutputTokens();
+            if (sessionTotal > 0) {
+                plugin.getStatsManager().addTokens(sessionTotal);
             }
         }
 
@@ -2394,7 +2400,7 @@ public class CLIManager {
                 }
             });
         });
-        
+
         streamingHandler.setOnErrorCallback((error) -> {
             if (responseHandled[0]) return;
             responseHandled[0] = true;
@@ -2542,6 +2548,7 @@ public class CLIManager {
         }
         
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            plugin.getStatsManager().incrementConversation();
             ai.setRetryCallback((statusCode, retryMessage) -> {
                 if (!plugin.isEnabled()) return;
                 Bukkit.getScheduler().runTask(plugin, () -> {

--- a/src/main/java/org/YanPl/manager/StatsManager.java
+++ b/src/main/java/org/YanPl/manager/StatsManager.java
@@ -1,0 +1,102 @@
+package org.YanPl.manager;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.YanPl.FancyHelper;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.SingleLineChart;
+import org.bukkit.Bukkit;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class StatsManager {
+    private final FancyHelper plugin;
+    private final AtomicLong totalTokens = new AtomicLong(0);
+    private final AtomicLong cliEntryCount = new AtomicLong(0);
+    private final AtomicLong conversationCount = new AtomicLong(0);
+    private final Gson gson = new Gson();
+    private final File dataFile;
+    private final Object saveLock = new Object();
+
+    public StatsManager(FancyHelper plugin, Metrics metrics) {
+        this.plugin = plugin;
+        this.dataFile = new File(plugin.getDataFolder(), "temp/stats.json");
+        load();
+        registerCharts(metrics);
+        startAutoSave();
+    }
+
+    private void startAutoSave() {
+        Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::save, 6000L, 6000L);
+    }
+
+    private void load() {
+        if (!dataFile.exists()) return;
+        try (FileReader reader = new FileReader(dataFile)) {
+            JsonObject json = gson.fromJson(reader, JsonObject.class);
+            if (json != null) {
+                if (json.has("totalTokens")) totalTokens.set(json.get("totalTokens").getAsLong());
+                if (json.has("cliEntryCount")) cliEntryCount.set(json.get("cliEntryCount").getAsLong());
+                if (json.has("conversationCount")) conversationCount.set(json.get("conversationCount").getAsLong());
+            }
+        } catch (IOException e) {
+            plugin.getLogger().warning("[StatsManager] 加载统计数据失败: " + e.getMessage());
+        }
+    }
+
+    public void save() {
+        synchronized (saveLock) {
+            try {
+                if (!dataFile.getParentFile().exists()) {
+                    dataFile.getParentFile().mkdirs();
+                }
+                JsonObject json = new JsonObject();
+                json.addProperty("totalTokens", totalTokens.get());
+                json.addProperty("cliEntryCount", cliEntryCount.get());
+                json.addProperty("conversationCount", conversationCount.get());
+                try (FileWriter writer = new FileWriter(dataFile)) {
+                    gson.toJson(json, writer);
+                }
+            } catch (IOException e) {
+                plugin.getLogger().warning("[StatsManager] 保存统计数据失败: " + e.getMessage());
+            }
+        }
+    }
+
+    private void registerCharts(Metrics metrics) {
+        metrics.addCustomChart(new SingleLineChart("total_tokens", this::getTotalTokens));
+        metrics.addCustomChart(new SingleLineChart("cli_entries", this::getCliEntryCount));
+        metrics.addCustomChart(new SingleLineChart("total_conversations", this::getConversationCount));
+    }
+
+    public void addTokens(long tokens) {
+        totalTokens.addAndGet(tokens);
+    }
+
+    public void incrementCliEntry() {
+        cliEntryCount.incrementAndGet();
+    }
+
+    public void incrementConversation() {
+        conversationCount.incrementAndGet();
+    }
+
+    public int getTotalTokens() {
+        long val = totalTokens.get();
+        return val > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) val;
+    }
+
+    public int getCliEntryCount() {
+        long val = cliEntryCount.get();
+        return val > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) val;
+    }
+
+    public int getConversationCount() {
+        long val = conversationCount.get();
+        return val > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) val;
+    }
+}


### PR DESCRIPTION
## Summary

为 bStats 添加 3 个自定义 `SingleLineChart`，追踪插件使用数据：
- **总 Token 消耗** (`total_tokens`) — 累计的 input + output token
- **CLI 进入次数** (`cli_entries`) — 玩家进入 CLI 模式的次数
- **对话总次数** (`total_conversations`) — AI 对话发起的次数
