### PR TITLE
chore: 下载镜像源由 gh-proxy.com 更换为 ghproxy.vip

### DIFF
--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -356,7 +356,7 @@ public class ConfigManager {
      * 获取 Skill 下载镜像源
      */
     public String getSkillUpdateMirror() {
-        return config.getString("settings.skill_update_mirror", "https://gh-proxy.com/");
+        return config.getString("settings.skill_update_mirror", "https://ghproxy.vip/");
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -65,7 +65,7 @@ public class UpdateManager implements Listener {
 
             try {
                 // 优先通过镜像代理 API 请求，避免 GitHub 频率限制
-                String mirror = "https://gh-proxy.com/";
+                String mirror = "https://ghproxy.vip/";
                 HttpResponse<String> response;
                 try {
                     response = fetchApiResponse(client, mirror + repoUrl);
@@ -243,7 +243,7 @@ public class UpdateManager implements Listener {
         if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f开始下载更新..."));
 
         Runnable downloadTask = () -> {
-            String mirror = "https://gh-proxy.com/";
+            String mirror = "https://ghproxy.vip/";
             String finalUrl = mirror + downloadUrl;
 
             if (plugin.getConfigManager().isDebug()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,7 +32,7 @@ settings:
   # Skill 远程仓库地址
   skill_repo_base: "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/"
   # Skill 下载镜像源
-  skill_update_mirror: "https://gh-proxy.com/"  
+  skill_update_mirror: "https://ghproxy.vip/"
   # 防循环检测的连续相似调用阈值
   anti_loop:
     # 连续多少次相似调用触发中断


### PR DESCRIPTION
## Summary
- 将所有下载镜像源从 `gh-proxy.com` 更换为 `ghproxy.vip`（Skill 更新 + 插件自更新）

## Changes
- `config.yml` — 默认 Skill 镜像源配置
- `ConfigManager.java` — `getSkillUpdateMirror()` 默认值
- `UpdateManager.java` — 插件更新两处硬编码镜像