### PR TITLE
feat: 迁移 Skill/插件下载至 Cloudflare CDN，支持三级级联留底

### DIFF
--- a/.github/workflows/CI-Build-Release.yml
+++ b/.github/workflows/CI-Build-Release.yml
@@ -212,6 +212,88 @@ jobs:
             fi
           done
 
+      - name: 上传版本信息到 Worker
+        env:
+          PLUGIN_UPLOAD_TOKEN: ${{ secrets.PLUGIN_UPLOAD_TOKEN }}
+          WORKER_VERSION_URL: ${{ secrets.WORKER_VERSION_URL }}
+        run: |
+          IS_RELEASE="${{ needs.build.outputs.IS_RELEASE }}"
+
+          for jar in artifacts/FancyHelper-*.jar; do
+            if [[ -f "$jar" ]]; then
+              FILENAME=$(basename "$jar")
+              VERSION="${FILENAME#FancyHelper-}"
+              VERSION="${VERSION%.jar}"
+              SHA256=$(sha256sum "$jar" | cut -d' ' -f1)
+
+              if [[ "$IS_RELEASE" == "true" ]]; then
+                UPLOAD_DIR="releases"
+              else
+                UPLOAD_DIR="snapshots"
+              fi
+              DOWNLOAD_URL="https://fancy.baicaizhale.top/download/${UPLOAD_DIR}/${FILENAME}"
+
+              echo "上传版本信息: ${VERSION} (${FILENAME})"
+
+              curl -s -X POST "${WORKER_VERSION_URL}/api/plugin/upload" \
+                -H "Authorization: Bearer ${PLUGIN_UPLOAD_TOKEN}" \
+                -H "Content-Type: application/json" \
+                -d "{
+                  \"version\": \"${VERSION}\",
+                  \"file_name\": \"${FILENAME}\",
+                  \"download_url\": \"${DOWNLOAD_URL}\",
+                  \"sha256\": \"${SHA256}\"
+                }"
+
+              echo ""
+              echo "版本信息已上传: ${VERSION}"
+              break
+            fi
+          done
+
+      - name: 上传 Release 版本信息（含更新日志）
+        if: needs.build.outputs.IS_RELEASE == 'true'
+        env:
+          PLUGIN_UPLOAD_TOKEN: ${{ secrets.PLUGIN_UPLOAD_TOKEN }}
+          WORKER_VERSION_URL: ${{ secrets.WORKER_VERSION_URL }}
+        run: |
+          for jar in artifacts/FancyHelper-*.jar; do
+            if [[ -f "$jar" ]]; then
+              FILENAME=$(basename "$jar")
+              VERSION="${FILENAME#FancyHelper-}"
+              VERSION="${VERSION%.jar}"
+              SHA256=$(sha256sum "$jar" | cut -d' ' -f1)
+              DOWNLOAD_URL="https://fancy.baicaizhale.top/download/releases/${FILENAME}"
+
+              CHANGELOG=$(curl -sL "https://api.github.com/repos/baicaizhale/FancyHelper/releases/tags/v${VERSION}" \
+                | jq -r '.body // empty' 2>/dev/null | head -c 5000 || echo "")
+
+              if [[ -z "$CHANGELOG" ]]; then
+                if [[ -f "release_body.md" ]]; then
+                  CHANGELOG=$(head -c 5000 release_body.md)
+                fi
+              fi
+
+              echo "上传 Release 版本信息（含更新日志）: ${VERSION}"
+
+              jq -n \
+                --arg version "$VERSION" \
+                --arg file_name "$FILENAME" \
+                --arg download_url "$DOWNLOAD_URL" \
+                --arg sha256 "$SHA256" \
+                --arg changelog "$CHANGELOG" \
+                '{version: $version, file_name: $file_name, download_url: $download_url, sha256: $sha256, changelog: $changelog}' \
+                | curl -s -X POST "${WORKER_VERSION_URL}/api/plugin/upload" \
+                  -H "Authorization: Bearer ${PLUGIN_UPLOAD_TOKEN}" \
+                  -H "Content-Type: application/json" \
+                  -d @-
+
+              echo ""
+              echo "Release 版本信息已上传: ${VERSION}"
+              break
+            fi
+          done
+
   # ==================== AI 生成发行注记 ====================
   # 需要配置 CLOUDFLARE_API_KEY 密钥，该密钥需要有 Workers AI 权限
   generate-overview:

--- a/.github/workflows/CI-Build-Release.yml
+++ b/.github/workflows/CI-Build-Release.yml
@@ -217,8 +217,6 @@ jobs:
           PLUGIN_UPLOAD_TOKEN: ${{ secrets.PLUGIN_UPLOAD_TOKEN }}
           WORKER_VERSION_URL: ${{ secrets.WORKER_VERSION_URL }}
         run: |
-          IS_RELEASE="${{ needs.build.outputs.IS_RELEASE }}"
-
           for jar in artifacts/FancyHelper-*.jar; do
             if [[ -f "$jar" ]]; then
               FILENAME=$(basename "$jar")
@@ -226,22 +224,13 @@ jobs:
               VERSION="${VERSION%.jar}"
               SHA256=$(sha256sum "$jar" | cut -d' ' -f1)
 
-              if [[ "$IS_RELEASE" == "true" ]]; then
-                UPLOAD_DIR="releases"
-              else
-                UPLOAD_DIR="snapshots"
-              fi
-              DOWNLOAD_URL="https://fancy.baicaizhale.top/download/${UPLOAD_DIR}/${FILENAME}"
-
-              echo "上传版本信息: ${VERSION} (${FILENAME})"
+              echo "上传版本信息: ${VERSION}"
 
               curl -s -X POST "${WORKER_VERSION_URL}/api/plugin/upload" \
                 -H "Authorization: Bearer ${PLUGIN_UPLOAD_TOKEN}" \
                 -H "Content-Type: application/json" \
                 -d "{
                   \"version\": \"${VERSION}\",
-                  \"file_name\": \"${FILENAME}\",
-                  \"download_url\": \"${DOWNLOAD_URL}\",
                   \"sha256\": \"${SHA256}\"
                 }"
 
@@ -263,26 +252,21 @@ jobs:
               VERSION="${FILENAME#FancyHelper-}"
               VERSION="${VERSION%.jar}"
               SHA256=$(sha256sum "$jar" | cut -d' ' -f1)
-              DOWNLOAD_URL="https://fancy.baicaizhale.top/download/releases/${FILENAME}"
 
               CHANGELOG=$(curl -sL "https://api.github.com/repos/baicaizhale/FancyHelper/releases/tags/v${VERSION}" \
                 | jq -r '.body // empty' 2>/dev/null | head -c 5000 || echo "")
 
-              if [[ -z "$CHANGELOG" ]]; then
-                if [[ -f "release_body.md" ]]; then
-                  CHANGELOG=$(head -c 5000 release_body.md)
-                fi
+              if [[ -z "$CHANGELOG" && -f "release_body.md" ]]; then
+                CHANGELOG=$(head -c 5000 release_body.md)
               fi
 
               echo "上传 Release 版本信息（含更新日志）: ${VERSION}"
 
               jq -n \
                 --arg version "$VERSION" \
-                --arg file_name "$FILENAME" \
-                --arg download_url "$DOWNLOAD_URL" \
                 --arg sha256 "$SHA256" \
                 --arg changelog "$CHANGELOG" \
-                '{version: $version, file_name: $file_name, download_url: $download_url, sha256: $sha256, changelog: $changelog}' \
+                '{version: $version, sha256: $sha256, changelog: $changelog}' \
                 | curl -s -X POST "${WORKER_VERSION_URL}/api/plugin/upload" \
                   -H "Authorization: Bearer ${PLUGIN_UPLOAD_TOKEN}" \
                   -H "Content-Type: application/json" \

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -25,6 +25,10 @@ public class ConfigManager {
     private static final String SKILL_REPO_BASE = "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/";
     private static final String SKILL_UPDATE_MIRROR = "https://ghproxy.vip/";
 
+    // 插件更新相关
+    private static final String PLUGIN_VERSION_API = "https://fancy-version.baicaizhale.top/api/plugin/latest";
+    private static final String PLUGIN_CDN_BASE = "https://fancy.baicaizhale.top/";
+
     public ConfigManager(FancyHelper plugin) {
         this.plugin = plugin;
         checkAndUpdateConfig();
@@ -354,6 +358,20 @@ public class ConfigManager {
      */
     public String getSkillPrimaryMirror() {
         return SKILL_PRIMARY_MIRROR;
+    }
+
+    /**
+     * 获取插件版本信息 API 地址
+     */
+    public String getPluginVersionApi() {
+        return PLUGIN_VERSION_API;
+    }
+
+    /**
+     * 获取插件 CDN 下载基地址
+     */
+    public String getPluginCdnBase() {
+        return PLUGIN_CDN_BASE;
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -21,6 +21,10 @@ public class ConfigManager {
     private FileConfiguration playerData;
     private File playerDataFile;
 
+    private static final String SKILL_PRIMARY_MIRROR = "https://fancy-skill.baicaizhale.top/";
+    private static final String SKILL_REPO_BASE = "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/";
+    private static final String SKILL_UPDATE_MIRROR = "https://ghproxy.vip/";
+
     public ConfigManager(FancyHelper plugin) {
         this.plugin = plugin;
         checkAndUpdateConfig();
@@ -346,17 +350,24 @@ public class ConfigManager {
     }
 
     /**
-     * 获取 Skill 远程仓库地址
+     * 获取 Skill 主下载源
      */
-    public String getSkillRepoBase() {
-        return config.getString("settings.skill_repo_base", "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/");
+    public String getSkillPrimaryMirror() {
+        return SKILL_PRIMARY_MIRROR;
     }
 
     /**
-     * 获取 Skill 下载镜像源
+     * 获取 Skill 远程仓库地址
+     */
+    public String getSkillRepoBase() {
+        return SKILL_REPO_BASE;
+    }
+
+    /**
+     * 获取 Skill 下载镜像源（旧 ghproxy 留底）
      */
     public String getSkillUpdateMirror() {
-        return config.getString("settings.skill_update_mirror", "https://ghproxy.vip/");
+        return SKILL_UPDATE_MIRROR;
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/SkillUpdateManager.java
+++ b/src/main/java/org/YanPl/manager/SkillUpdateManager.java
@@ -58,16 +58,17 @@ public class SkillUpdateManager implements Listener {
         return ColorUtil.translateCustomColors("§zFancyHelper §7> §f" + text);
     }
 
-    private String getManifestUrl() {
-        String mirror = plugin.getConfigManager().getSkillUpdateMirror();
-        String base = plugin.getConfigManager().getSkillRepoBase();
-        return mirror + base + "manifest.json";
+    private String getPrimaryUrl(String path) {
+        return plugin.getConfigManager().getSkillPrimaryMirror() + path;
     }
 
-    private String getSkillFileUrl(String skillId) {
-        String mirror = plugin.getConfigManager().getSkillUpdateMirror();
-        String base = plugin.getConfigManager().getSkillRepoBase();
-        return mirror + base + skillId + "/skill.md";
+    private String getMirrorUrl(String path) {
+        return plugin.getConfigManager().getSkillUpdateMirror()
+                + plugin.getConfigManager().getSkillRepoBase() + path;
+    }
+
+    private String getDirectUrl(String path) {
+        return plugin.getConfigManager().getSkillRepoBase() + path;
     }
 
     // ==================== 公开方法 ====================
@@ -79,10 +80,6 @@ public class SkillUpdateManager implements Listener {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
                 doCheck(null, true);
-                if (hasUpdates && !pendingUpdates.isEmpty()) {
-                    plugin.getLogger().info("[SkillUpdate] 发现 " + pendingUpdates.size() + " 个 Skill 更新，开始自动下载...");
-                    doDownload(null);
-                }
             } catch (Exception e) {
                 plugin.getLogger().warning("[SkillUpdate] 自动更新失败: " + e.getMessage());
             }
@@ -149,10 +146,13 @@ public class SkillUpdateManager implements Listener {
         hasUpdates = false;
 
         try {
-            String body = fetchWithFallback(getManifestUrl(), plugin.getConfigManager().getSkillRepoBase() + "manifest.json");
+            String body = fetchWithFallback(
+                    getPrimaryUrl("manifest.json"),
+                    getMirrorUrl("manifest.json"),
+                    getDirectUrl("manifest.json"));
             if (body == null) {
-                notify(sender, "§c获取 Skill 更新清单失败");
-                plugin.getLogger().warning("[SkillUpdate] 获取 manifest 失败（镜像+直连均不可用）");
+                notify(sender, "§c获取 Skill 更新清单失败（主源/镜像/直连均不可用）");
+                plugin.getLogger().warning("[SkillUpdate] 获取 manifest 失败（主源/镜像/直连均不可用）");
                 return;
             }
 
@@ -197,7 +197,7 @@ public class SkillUpdateManager implements Listener {
 
             if (sender != null) {
                 if (hasUpdates) {
-                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper §7> §a发现 §e" + updateCount + " §a个 Skill 可更新"));
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper §7> §a发现 §e" + updateCount + " §a个 Skill 更新，正在自动下载..."));
                     for (Map.Entry<String, String> entry : pendingUpdates.entrySet()) {
                         Skill local = skillManager.getSkill(entry.getKey());
                         String localVer = local != null ? local.getMetadata().getVersion() : "未安装";
@@ -209,7 +209,8 @@ public class SkillUpdateManager implements Listener {
             }
 
             if (hasUpdates) {
-                plugin.getLogger().info("[SkillUpdate] 发现 " + updateCount + " 个 Skill 可更新");
+                plugin.getLogger().info("[SkillUpdate] 发现 " + updateCount + " 个 Skill 可更新，开始自动下载...");
+                doDownload(sender);
             } else {
                 plugin.getLogger().info("[SkillUpdate] 所有 Skill 已是最新 (" + checkedCount + " 个检查)");
             }
@@ -260,13 +261,15 @@ public class SkillUpdateManager implements Listener {
      * 下载单个 Skill 文件到 skills 目录
      */
     private boolean downloadSkillFile(String skillId) {
-        String mirrorUrl = getSkillFileUrl(skillId);
-        String directUrl = plugin.getConfigManager().getSkillRepoBase() + skillId + "/skill.md";
+        String path = skillId + "/skill.md";
         SkillLoader loader = skillManager.getLoader();
 
         try {
-            // 优先镜像，失败回退直连
-            HttpResponse<InputStream> response = fetchInputStreamWithFallback(mirrorUrl, directUrl);
+            // 三级级联：主源 → 镜像(ghproxy) → 直连(GitHub)
+            HttpResponse<InputStream> response = fetchInputStreamWithFallback(
+                    getPrimaryUrl(path),
+                    getMirrorUrl(path),
+                    getDirectUrl(path));
             if (response == null || response.statusCode() != 200) {
                 int code = response != null ? response.statusCode() : 0;
                 plugin.getLogger().warning("[SkillUpdate] 下载 " + skillId + " 失败: HTTP " + code);
@@ -318,69 +321,77 @@ public class SkillUpdateManager implements Listener {
     }
 
     /**
-     * 请求 URL 获取文本，优先走镜像，失败回退直连。
-     * @return 响应体，失败返回 null
+     * 三级级联请求：主源 → 镜像(ghproxy) → 直连(GitHub)
+     * @return 响应体，全部失败返回 null
      */
-    private String fetchWithFallback(String mirrorUrl, String directUrl) {
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(mirrorUrl))
-                    .header("User-Agent", "FancyHelper-SkillUpdater")
-                    .timeout(Duration.ofSeconds(15))
-                    .GET()
-                    .build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() == 200) return response.body();
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+    private String fetchWithFallback(String primaryUrl, String mirrorUrl, String directUrl) {
+        // 第一层：主源
+        String body = tryFetchString(primaryUrl);
+        if (body != null) return body;
+        plugin.getLogger().info("[SkillUpdate] 主源不可用，尝试镜像源...");
+
+        // 第二层：镜像(ghproxy)
+        body = tryFetchString(mirrorUrl);
+        if (body != null) return body;
+        plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连...");
+
+        // 第三层：直连(GitHub)
+        body = tryFetchString(directUrl);
+        if (body == null) {
+            plugin.getLogger().warning("[SkillUpdate] 直连也失败");
         }
-        // 回退直连
+        return body;
+    }
+
+    private String tryFetchString(String url) {
         try {
-            plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连...");
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(directUrl))
+                    .uri(URI.create(url))
                     .header("User-Agent", "FancyHelper-SkillUpdater")
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() == 200) return response.body();
-            plugin.getLogger().warning("[SkillUpdate] 直连返回 HTTP " + response.statusCode());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
-            plugin.getLogger().warning("[SkillUpdate] 直连请求失败: " + e.getMessage());
         }
         return null;
     }
 
     /**
-     * 请求 URL 获取输入流，优先走镜像，失败回退直连。
-     * @return 响应，失败返回 null
+     * 三级级联请求输入流：主源 → 镜像(ghproxy) → 直连(GitHub)
+     * @return 响应，全部失败返回 null
      */
-    private HttpResponse<InputStream> fetchInputStreamWithFallback(String mirrorUrl, String directUrl) {
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(mirrorUrl))
-                    .header("User-Agent", "FancyHelper-SkillUpdater")
-                    .timeout(Duration.ofSeconds(30))
-                    .GET()
-                    .build();
-            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-            if (response.statusCode() == 200) return response;
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+    private HttpResponse<InputStream> fetchInputStreamWithFallback(String primaryUrl, String mirrorUrl, String directUrl) {
+        // 第一层：主源
+        HttpResponse<InputStream> response = tryFetchStream(primaryUrl);
+        if (response != null && response.statusCode() == 200) return response;
+        plugin.getLogger().info("[SkillUpdate] 主源不可用，尝试镜像源下载...");
+
+        // 第二层：镜像(ghproxy)
+        response = tryFetchStream(mirrorUrl);
+        if (response != null && response.statusCode() == 200) return response;
+        plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连下载...");
+
+        // 第三层：直连(GitHub)
+        response = tryFetchStream(directUrl);
+        if (response == null || response.statusCode() != 200) {
+            int code = response != null ? response.statusCode() : 0;
+            plugin.getLogger().warning("[SkillUpdate] 直连下载返回 HTTP " + code);
         }
-        // 回退直连
+        return response;
+    }
+
+    private HttpResponse<InputStream> tryFetchStream(String url) {
         try {
-            plugin.getLogger().info("[SkillUpdate] 镜像源不可用，尝试直连下载...");
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(directUrl))
+                    .uri(URI.create(url))
                     .header("User-Agent", "FancyHelper-SkillUpdater")
                     .timeout(Duration.ofSeconds(30))
                     .GET()
                     .build();
-            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-            if (response.statusCode() == 200) return response;
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
         }

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -1,7 +1,5 @@
 package org.YanPl.manager;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.YanPl.FancyHelper;
@@ -25,15 +23,18 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 
 /**
- * 更新管理器：负责从 GitHub 获取最新版本并提醒管理员。
+ * 更新管理器：从 Cloudflare Worker 获取最新版本，并通过三级级联下载 JAR。
  */
 public class UpdateManager implements Listener {
     private final FancyHelper plugin;
-    private final String repoUrl = "https://api.github.com/repos/baicaizhale/FancyHelper/releases/latest";
+
+    private static final String GITHUB_API_URL = "https://api.github.com/repos/baicaizhale/FancyHelper/releases/latest";
+    private static final String GITHUB_DL_BASE = "https://github.com/baicaizhale/FancyHelper/releases/download/";
+
     private String latestVersion = null;
     private String downloadUrl = null;
     private String latestFileName = null;
-    private String releaseOverview = null; // Release Overview (AI生成的版本概述)
+    private String releaseOverview = null;
     private boolean hasUpdate = false;
 
     public UpdateManager(FancyHelper plugin) {
@@ -50,7 +51,6 @@ public class UpdateManager implements Listener {
 
     /**
      * 检查更新并通知特定玩家。
-     * @param sender 通知对象（可为 null，仅输出到控制台）
      */
     public void checkForUpdates(Player sender) {
         if (!plugin.getConfigManager().isCheckUpdate() && sender == null) {
@@ -58,157 +58,180 @@ public class UpdateManager implements Listener {
         }
 
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(10))
-                    .followRedirects(HttpClient.Redirect.NORMAL)
-                    .build();
-
             try {
-                // 优先通过镜像代理 API 请求，避免 GitHub 频率限制
-                String mirror = "https://ghproxy.vip/";
-                HttpResponse<String> response;
-                try {
-                    response = fetchApiResponse(client, mirror + repoUrl);
-                } catch (IOException e) {
-                    plugin.getLogger().info("镜像代理连接失败 (" + e.getMessage() + ")，尝试直连...");
-                    response = fetchApiResponse(client, repoUrl);
-                }
-                if (response.statusCode() != 200) {
-                    plugin.getLogger().info("镜像代理 API 返回 " + response.statusCode() + "，回退直连...");
-                    response = fetchApiResponse(client, repoUrl);
+                // 第一层：从 Cloudflare Worker 获取版本信息
+                boolean fetched = fetchFromWorkerApi(sender);
+
+                // 第二层：回退到 GitHub API（ghproxy + 直连）
+                if (!fetched) {
+                    fetched = fetchFromGitHubApi(sender);
                 }
 
-                if (response.statusCode() == 200) {
-                    String jsonResponse = response.body();
-                    JsonObject jsonObject = JsonParser.parseString(jsonResponse).getAsJsonObject();
-
-                    if (!jsonObject.has("tag_name") || jsonObject.get("tag_name").isJsonNull()) {
-                        plugin.getLogger().warning("检查更新失败：响应中缺少 tag_name 字段");
-                        return;
+                if (!fetched) {
+                    if (sender != null) {
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败（Worker/GitHub API 均不可用）。"));
                     }
-                    latestVersion = jsonObject.get("tag_name").getAsString().replace("v", "");
+                    return;
+                }
 
-                    // 获取 Release Overview (body 字段的前半部分，AI 生成的内容)
-                    if (jsonObject.has("body") && !jsonObject.get("body").isJsonNull()) {
-                        String body = jsonObject.get("body").getAsString();
-                        // 提取 Overview 部分（## 🚀 版本概述 到 ## What's Changed 之前）
-                        releaseOverview = extractOverview(body);
-                    }
+                String currentVersion = plugin.getDescription().getVersion();
+                if (isNewerVersion(currentVersion, latestVersion)) {
+                    hasUpdate = true;
+                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: v" + latestVersion));
+                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f下载地址: " + downloadUrl));
 
-                    // 获取第一个 .jar 文件的下载地址和文件名
-                    if (!jsonObject.has("assets") || jsonObject.get("assets").isJsonNull()) {
-                        plugin.getLogger().warning("检查更新失败：响应中缺少 assets 字段");
-                        return;
-                    }
-                    JsonArray assets = jsonObject.getAsJsonArray("assets");
-                    for (JsonElement assetElement : assets) {
-                        JsonObject asset = assetElement.getAsJsonObject();
-                        String name = asset.get("name").getAsString();
-                        if (name.endsWith(".jar")) {
-                            downloadUrl = asset.get("browser_download_url").getAsString();
-                            latestFileName = name;
-                            break;
+                    if (releaseOverview != null && !releaseOverview.isEmpty()) {
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                        for (String line : releaseOverview.split("\\r?\\n")) {
+                            String trimmedLine = line.trim();
+                            if (!trimmedLine.isEmpty()) {
+                                trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
+                                Bukkit.getConsoleSender().sendMessage(" §b§l> §r" + trimmedLine);
+                            }
                         }
                     }
 
-                    if (downloadUrl == null) {
-                        if (jsonObject.has("html_url") && !jsonObject.get("html_url").isJsonNull()) {
-                            downloadUrl = jsonObject.get("html_url").getAsString();
-                            latestFileName = "FancyHelper-v" + latestVersion + ".jar";
-                        } else {
-                            plugin.getLogger().warning("检查更新失败：无法获取下载链接");
-                            return;
-                        }
+                    if (plugin.getConfigManager().isAutoUpgrade()) {
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新..."));
+                        downloadAndInstall(null, true, true);
+                    } else {
+                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true"));
                     }
 
-                    String currentVersion = plugin.getDescription().getVersion();
-
-                    if (isNewerVersion(currentVersion, latestVersion)) {
-                        hasUpdate = true;
-                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: v" + latestVersion));
-                        Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f下载地址: " + downloadUrl));
-
-                        // 显示 Release Overview（控制台）
+                    if (sender != null) {
+                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion));
                         if (releaseOverview != null && !releaseOverview.isEmpty()) {
-                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
                             for (String line : releaseOverview.split("\\r?\\n")) {
                                 String trimmedLine = line.trim();
                                 if (!trimmedLine.isEmpty()) {
                                     trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
-                                    Bukkit.getConsoleSender().sendMessage(" §b§l> §r" + trimmedLine);
+                                    sender.sendMessage(" §b§l> §r" + trimmedLine);
                                 }
                             }
                         }
-
-                        // 自动升级逻辑
                         if (plugin.getConfigManager().isAutoUpgrade()) {
-                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到自动升级已开启，正在后台下载更新..."));
-                            downloadAndInstall(null, true, true);
+                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f正在执行自动更新..."));
                         } else {
-                            Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f如需自动下载更新，请将 config.yml 中的 auto_upgrade 设置为 true"));
-                        }
-
-                        if (sender != null) {
-                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: " + ChatColor.WHITE + "v" + latestVersion));
-                            // 显示 Release Overview
-                            if (releaseOverview != null && !releaseOverview.isEmpty()) {
-                                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
-                                // 使用正则表达式分割，支持 \n 和 \r\n
-                                for (String line : releaseOverview.split("\\r?\\n")) {
-                                    // 移除每行开头和结尾的空白字符
-                                    String trimmedLine = line.trim();
-                                    if (!trimmedLine.isEmpty()) {
-                                        // 移除 Markdown 列表符号 * - 等
-                                        trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
-                                        sender.sendMessage(" §b§l> §r" + trimmedLine);
-                                    }
-                                }
-                            }
-                            if (plugin.getConfigManager().isAutoUpgrade()) {
-                                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f正在执行自动更新..."));
-                            } else {
-                                sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.WHITE + " 自动下载并更新。"));
-                            }
-                        }
-                    } else {
-                        hasUpdate = false;
-                        // 无论 sender 是否为 null，都输出检查结果
-                        String message = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")");
-                        if (sender != null) {
-                            sender.sendMessage(message);
-                        } else {
-                            Bukkit.getConsoleSender().sendMessage(message);
+                            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 " + ChatColor.AQUA + "/fancy upgrade" + ChatColor.WHITE + " 自动下载并更新。"));
                         }
                     }
                 } else {
-                    int code = response.statusCode();
-                    if (code == 403 || code == 429) {
-                        plugin.getLogger().info("GitHub API 访问受限（频率限制），跳过本次更新检查");
-                    } else {
-                        plugin.getLogger().warning("检查更新失败 - HTTP " + code);
-                    }
+                    hasUpdate = false;
+                    String message = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前已是最新版本 (v" + currentVersion + ")");
                     if (sender != null) {
-                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败（HTTP " + code + "）。"));
+                        sender.sendMessage(message);
+                    } else {
+                        Bukkit.getConsoleSender().sendMessage(message);
                     }
                 }
-            } catch (IOException e) {
+
+            } catch (Exception e) {
                 plugin.getLogger().warning("检查更新失败: " + e.getMessage());
                 if (sender != null) {
                     sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新失败: " + e.getMessage()));
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                plugin.getLogger().warning("检查更新被中断: " + e.getMessage());
-                if (sender != null) {
-                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检查更新被中断: " + e.getMessage()));
                 }
             }
         });
     }
 
     /**
+     * 从 Cloudflare Worker API 获取版本信息
+     */
+    private boolean fetchFromWorkerApi(Player sender) {
+        try {
+            String apiUrl = plugin.getConfigManager().getPluginVersionApi();
+            String body = tryFetchString(apiUrl);
+
+            if (body == null) {
+                plugin.getLogger().info("[Update] Worker API 不可用，尝试 GitHub API...");
+                return false;
+            }
+
+            JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+            if (!json.has("version") || !json.has("download_url")) {
+                plugin.getLogger().warning("[Update] Worker API 返回格式异常");
+                return false;
+            }
+
+            latestVersion = json.get("version").getAsString().replace("v", "");
+            downloadUrl = json.get("download_url").getAsString();
+            latestFileName = json.has("file_name") ? json.get("file_name").getAsString() : ("FancyHelper-v" + latestVersion + ".jar");
+            releaseOverview = json.has("changelog") && !json.get("changelog").isJsonNull()
+                    ? json.get("changelog").getAsString() : null;
+
+            plugin.getLogger().info("[Update] 从 Worker 获取版本信息成功: v" + latestVersion);
+            return true;
+
+        } catch (Exception e) {
+            plugin.getLogger().info("[Update] Worker API 请求异常: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 从 GitHub API 获取版本信息（ghproxy + 直连回退）
+     */
+    private boolean fetchFromGitHubApi(Player sender) {
+        try {
+            String mirror = "https://ghproxy.vip/";
+            String body = tryFetchString(mirror + GITHUB_API_URL);
+
+            if (body == null) {
+                plugin.getLogger().info("[Update] GitHub API 镜像不可用，尝试直连...");
+                body = tryFetchString(GITHUB_API_URL);
+            }
+
+            if (body == null) {
+                plugin.getLogger().warning("[Update] GitHub API 直连也失败");
+                return false;
+            }
+
+            JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+            if (!json.has("tag_name") || json.get("tag_name").isJsonNull()) {
+                plugin.getLogger().warning("[Update] GitHub API 响应中缺少 tag_name");
+                return false;
+            }
+
+            latestVersion = json.get("tag_name").getAsString().replace("v", "");
+
+            if (json.has("body") && !json.get("body").isJsonNull()) {
+                releaseOverview = extractOverview(json.get("body").getAsString());
+            }
+
+            if (json.has("assets") && !json.get("assets").isJsonNull()) {
+                var assets = json.getAsJsonArray("assets");
+                for (var element : assets) {
+                    var asset = element.getAsJsonObject();
+                    String name = asset.get("name").getAsString();
+                    if (name.endsWith(".jar")) {
+                        downloadUrl = asset.get("browser_download_url").getAsString();
+                        latestFileName = name;
+                        break;
+                    }
+                }
+            }
+
+            if (downloadUrl == null) {
+                if (json.has("html_url") && !json.get("html_url").isJsonNull()) {
+                    downloadUrl = json.get("html_url").getAsString();
+                    latestFileName = "FancyHelper-v" + latestVersion + ".jar";
+                } else {
+                    return false;
+                }
+            }
+
+            plugin.getLogger().info("[Update] 从 GitHub API 获取版本信息成功: v" + latestVersion);
+            return true;
+
+        } catch (Exception e) {
+            plugin.getLogger().warning("[Update] GitHub API 请求异常: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
      * 下载并安装更新。
-     * @param sender 发起更新的玩家（可为 null）
      */
     public void downloadAndInstall(Player sender) {
         downloadAndInstall(sender, false);
@@ -216,71 +239,45 @@ public class UpdateManager implements Listener {
 
     /**
      * 下载并安装更新。
-     * @param sender 发起更新的玩家（可为 null）
-     * @param autoReload 是否在下载完成后自动重载
      */
     public void downloadAndInstall(Player sender, boolean autoReload) {
         downloadAndInstall(sender, autoReload, false);
     }
 
     /**
-     * 下载并安装更新。
-     * @param sender 发起更新的玩家（可为 null）
-     * @param autoReload 是否在下载完成后自动重载
-     * @param alreadyAsync 是否已经在异步任务中执行
+     * 下载并安装更新（三级级联：Worker CDN → ghproxy → GitHub 直连）。
      */
     public void downloadAndInstall(Player sender, boolean autoReload, boolean alreadyAsync) {
-        if (plugin.getConfigManager().isDebug()) {
-            plugin.getLogger().info("下载并安装更新被调用 - 有可用更新: " + hasUpdate + ", 下载地址: " + downloadUrl);
-        }
-
         if (!hasUpdate || downloadUrl == null) {
-            if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前没有可用的更新。"));
-            plugin.getLogger().warning("无法下载更新：有可用更新=" + hasUpdate + ", 下载地址=" + downloadUrl);
+            String msg = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f当前没有可用的更新。");
+            if (sender != null) sender.sendMessage(msg);
+            plugin.getLogger().warning("无法下载更新：hasUpdate=" + hasUpdate + ", downloadUrl=" + downloadUrl);
             return;
         }
 
         if (sender != null) sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f开始下载更新..."));
 
         Runnable downloadTask = () -> {
-            String mirror = "https://ghproxy.vip/";
-            String finalUrl = mirror + downloadUrl;
-
-            if (plugin.getConfigManager().isDebug()) {
-                plugin.getLogger().info("开始下载更新，镜像源: " + mirror);
-                plugin.getLogger().info("下载URL: " + finalUrl);
-            }
-
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(30))
-                    .build();
-
             try {
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(finalUrl))
-                        .header("User-Agent", "FancyHelper-Updater")
-                        .timeout(Duration.ofSeconds(60))
-                        .GET()
-                        .build();
+                // 第一层：Worker CDN（fancy.baicaizhale.top/latest）
+                String primaryUrl = plugin.getConfigManager().getPluginCdnBase() + "latest";
 
-                HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+                // 第二层：ghproxy
+                String mirrorUrl = "https://ghproxy.vip/" + downloadUrl;
 
-                if (response.statusCode() != 200) {
-                    plugin.getLogger().severe("下载失败: " + response.statusCode());
-                    if (sender != null) {
-                        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f下载失败: " + response.statusCode()));
-                    }
-                    throw new IOException("下载失败: " + response.statusCode());
+                // 第三层：直连
+                String directUrl = downloadUrl;
+
+                HttpResponse<InputStream> response = fetchInputStreamWithFallback(primaryUrl, mirrorUrl, directUrl);
+
+                if (response == null || response.statusCode() != 200) {
+                    int code = response != null ? response.statusCode() : 0;
+                    throw new IOException("下载失败: HTTP " + code);
                 }
 
-                // 准备保存新版本
                 File pluginsDir = plugin.getDataFolder().getParentFile();
                 String newJarName = latestFileName;
                 File newJarFile = new File(pluginsDir, newJarName);
-                
-                if (plugin.getConfigManager().isDebug()) {
-                    plugin.getLogger().info("准备保存新版本到: " + newJarFile.getAbsolutePath());
-                }
 
                 try (InputStream inputStream = response.body()) {
                     Files.copy(inputStream, newJarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -288,20 +285,19 @@ public class UpdateManager implements Listener {
 
                 plugin.getLogger().info("文件下载完成，大小: " + newJarFile.length() + " 字节");
 
-                // 旧 JAR 删除由 ReloadService 在 FancyHelper 卸载后处理（避免 Paper 1.26.1+ 文件锁定）
-
+                String successMsg = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载完成！");
+                String versionMsg = ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f新版本已就绪: " + newJarName);
                 if (sender != null) {
-                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载完成！"));
-                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f新版本已就绪: " + newJarName));
+                    sender.sendMessage(successMsg);
+                    sender.sendMessage(versionMsg);
                 } else {
-                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载完成！"));
-                    Bukkit.getConsoleSender().sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f新版本已就绪: " + newJarName));
+                    Bukkit.getConsoleSender().sendMessage(successMsg);
+                    Bukkit.getConsoleSender().sendMessage(versionMsg);
                 }
 
                 if (autoReload) {
                     if (!plugin.isEnabled()) return;
                     Bukkit.getScheduler().runTask(plugin, () -> {
-                        // 通知 ReloadService，然后自卸载
                         if (plugin.signalReloadService("UPDATE", newJarName)) {
                             Bukkit.getPluginManager().disablePlugin(plugin);
                         } else {
@@ -309,21 +305,15 @@ public class UpdateManager implements Listener {
                         }
                     });
                 }
+
             } catch (IOException e) {
                 plugin.getLogger().severe("更新下载失败: " + e.getMessage());
                 if (sender != null) {
                     sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载失败: " + e.getMessage()));
                 }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                plugin.getLogger().severe("更新下载被中断: " + e.getMessage());
-                if (sender != null) {
-                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新下载被中断: " + e.getMessage()));
-                }
             }
         };
 
-        // 根据是否已经在异步任务中来决定如何执行
         if (alreadyAsync) {
             downloadTask.run();
         } else {
@@ -331,65 +321,93 @@ public class UpdateManager implements Listener {
         }
     }
 
-    /**
-     * 从 Release body 中提取 Overview 部分。
-     * @param body Release body 内容
-     * @return Overview 部分（AI 生成的版本概述）
-     */
-    private String extractOverview(String body) {
-        if (body == null || body.isEmpty()) {
-            return null;
+    // ==================== 三级级联 HTTP 工具方法 ====================
+
+    private String tryFetchString(String url) {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("User-Agent", "FancyHelper-Updater")
+                    .timeout(Duration.ofSeconds(15))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) return response.body();
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
         }
-        
-        // 查找 "## Overview" 的位置
-        int overviewStart = body.indexOf("## Overview");
-        if (overviewStart == -1) {
-            overviewStart = body.indexOf("## 🚀 版本概述");
-        }
-        if (overviewStart == -1) {
-            overviewStart = body.indexOf("## 版本概述");
-        }
-        if (overviewStart == -1) {
-            overviewStart = body.indexOf("## 🚀");
-        }
-        
-        if (overviewStart == -1) {
-            // 如果找不到特定标记，尝试获取第一段内容
-            overviewStart = 0;
-        }
-        
-        // 查找 "## What's Changed" 或 "## **Full Changelog**" 的位置作为结束
-        int overviewEnd = body.indexOf("## What's Changed");
-        if (overviewEnd == -1) {
-            overviewEnd = body.indexOf("## **Full Changelog**");
-        }
-        if (overviewEnd == -1) {
-            overviewEnd = body.indexOf("## Full Changelog");
-        }
-        
-        if (overviewEnd == -1) {
-            // 如果找不到结束标记，取前500字符或全部内容
-            overviewEnd = Math.min(body.length(), 500);
-        }
-        
-        String overview = body.substring(overviewStart, overviewEnd).trim();
-        
-        // 清理 Markdown 格式，转换为 Minecraft 格式
-        overview = overview.replace("## Overview", "")
-                           .replace("## 🚀 版本概述", "")
-                           .replace("## 版本概述", "")
-                           .replace("## 🚀", "")
-                           .trim();
-        
-        return overview;
+        return null;
     }
 
-    /**
-     * 比较版本号。
-     * @param current 当前版本
-     * @param latest 最新版本
-     * @return 如果最新版本大于当前版本则返回 true
-     */
+    private HttpResponse<InputStream> fetchInputStreamWithFallback(String primaryUrl, String mirrorUrl, String directUrl) {
+        // 第一层：Worker CDN
+        HttpResponse<InputStream> response = tryFetchStream(primaryUrl);
+        if (response != null && response.statusCode() == 200) return response;
+        plugin.getLogger().info("[Update] CDN 主源不可用，尝试 ghproxy...");
+
+        // 第二层：ghproxy
+        response = tryFetchStream(mirrorUrl);
+        if (response != null && response.statusCode() == 200) return response;
+        plugin.getLogger().info("[Update] ghproxy 不可用，尝试直连...");
+
+        // 第三层：直连
+        response = tryFetchStream(directUrl);
+        if (response == null || response.statusCode() != 200) {
+            int code = response != null ? response.statusCode() : 0;
+            plugin.getLogger().warning("[Update] 直连下载返回 HTTP " + code);
+        }
+        return response;
+    }
+
+    private HttpResponse<InputStream> tryFetchStream(String url) {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(30))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("User-Agent", "FancyHelper-Updater")
+                    .timeout(Duration.ofSeconds(60))
+                    .GET()
+                    .build();
+            return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+        }
+        return null;
+    }
+
+    // ==================== 事件监听 ====================
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!plugin.getConfigManager().isOpUpdateNotify()) return;
+        Player player = event.getPlayer();
+        if (hasUpdate && player.isOp()) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion));
+                if (releaseOverview != null && !releaseOverview.isEmpty()) {
+                    player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
+                    for (String line : releaseOverview.split("\\r?\\n")) {
+                        String trimmedLine = line.trim();
+                        if (!trimmedLine.isEmpty()) {
+                            trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
+                            player.sendMessage(" §b§l- §r" + trimmedLine);
+                        }
+                    }
+                }
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。"));
+            }, 40L);
+        }
+    }
+
+    // ==================== 版本比较 ====================
+
     private boolean isNewerVersion(String current, String latest) {
         if (current == null || latest == null) return false;
         return compareVersion(current, latest) < 0;
@@ -423,41 +441,43 @@ public class UpdateManager implements Listener {
         return num;
     }
 
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        if (!plugin.getConfigManager().isOpUpdateNotify()) {
-            return;
-        }
-        Player player = event.getPlayer();
-        if (hasUpdate && player.isOp()) {
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f检测到新版本: §a" + latestVersion));
-                // 显示 Release Overview
-                if (releaseOverview != null && !releaseOverview.isEmpty()) {
-                    player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f更新内容:"));
-                    // 使用正则表达式分割，支持 \n 和 \r\n
-                    for (String line : releaseOverview.split("\\r?\\n")) {
-                        // 移除每行开头和结尾的空白字符
-                        String trimmedLine = line.trim();
-                        if (!trimmedLine.isEmpty()) {
-                            // 移除 Markdown 列表符号 * - 等
-                            trimmedLine = trimmedLine.replaceFirst("^[*\\-\\d.]+\\s+", "");
-                            player.sendMessage(" §b§l- §r" + trimmedLine);
-                        }
-                    }
-                }
-                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f使用 §e/fancy upgrade §f自动下载并更新。"));
-            }, 40L); // 延迟 2 秒提示
-        }
+    /**
+     * 从 Release body 中提取 Overview 部分
+     */
+    private String extractOverview(String body) {
+        if (body == null || body.isEmpty()) return null;
+
+        int overviewStart = body.indexOf("## Overview");
+        if (overviewStart == -1) overviewStart = body.indexOf("## 🚀 版本概述");
+        if (overviewStart == -1) overviewStart = body.indexOf("## 版本概述");
+        if (overviewStart == -1) overviewStart = body.indexOf("## 🚀");
+        if (overviewStart == -1) overviewStart = 0;
+
+        int overviewEnd = body.indexOf("## What's Changed");
+        if (overviewEnd == -1) overviewEnd = body.indexOf("## **Full Changelog**");
+        if (overviewEnd == -1) overviewEnd = body.indexOf("## Full Changelog");
+        if (overviewEnd == -1) overviewEnd = Math.min(body.length(), 500);
+
+        String overview = body.substring(overviewStart, overviewEnd).trim();
+        overview = overview.replace("## Overview", "")
+                           .replace("## 🚀 版本概述", "")
+                           .replace("## 版本概述", "")
+                           .replace("## 🚀", "")
+                           .trim();
+        return overview;
     }
 
-    private HttpResponse<String> fetchApiResponse(HttpClient client, String url) throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .header("User-Agent", "FancyHelper-Updater")
-                .timeout(Duration.ofSeconds(10))
-                .GET()
-                .build();
-        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    // ==================== 状态查询 ====================
+
+    public boolean hasUpdate() {
+        return hasUpdate;
+    }
+
+    public String getLatestVersion() {
+        return latestVersion;
+    }
+
+    public String getReleaseOverview() {
+        return releaseOverview;
     }
 }

--- a/src/main/java/org/YanPl/manager/UpdateManager.java
+++ b/src/main/java/org/YanPl/manager/UpdateManager.java
@@ -149,14 +149,15 @@ public class UpdateManager implements Listener {
             }
 
             JsonObject json = JsonParser.parseString(body).getAsJsonObject();
-            if (!json.has("version") || !json.has("download_url")) {
+            if (!json.has("version")) {
                 plugin.getLogger().warning("[Update] Worker API 返回格式异常");
                 return false;
             }
 
             latestVersion = json.get("version").getAsString().replace("v", "");
-            downloadUrl = json.get("download_url").getAsString();
-            latestFileName = json.has("file_name") ? json.get("file_name").getAsString() : ("FancyHelper-v" + latestVersion + ".jar");
+            // 下载走 fancy.baicaizhale.top/latest，GitHub URL 作为留底
+            latestFileName = "FancyHelper-v" + latestVersion + ".jar";
+            downloadUrl = GITHUB_DL_BASE + "v" + latestVersion + "/" + latestFileName;
             releaseOverview = json.has("changelog") && !json.get("changelog").isJsonNull()
                     ? json.get("changelog").getAsString() : null;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,10 +29,6 @@ settings:
   op_update_notify: true
   # 是否在检测到新版本时自动下载并安装更新，Paper及下游服务端推荐开启（使用Spigot及上游服务端请关闭此选项，目前还是会出bug）
   auto_upgrade: true
-  # Skill 远程仓库地址
-  skill_repo_base: "https://raw.githubusercontent.com/baicaizhale/FancySkillMarket/main/"
-  # Skill 下载镜像源
-  skill_update_mirror: "https://ghproxy.vip/"
   # 防循环检测的连续相似调用阈值
   anti_loop:
     # 连续多少次相似调用触发中断

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,126 @@
+/**
+ * FancyHelper Plugin Version Worker
+ *
+ * GET  /api/plugin/latest  — 返回最新版本信息（公开）
+ * POST /api/plugin/upload  — 上传版本信息（需 Bearer token 鉴权）
+ */
+
+// UPLOAD_TOKEN 通过 wrangler secret put 设置，自 env 参数传入
+
+// KV key
+const KV_KEY = 'plugin:latest';
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // CORS headers
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    };
+
+    // Handle CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders });
+    }
+
+    try {
+      // GET /api/plugin/latest — 获取最新版本信息（公开）
+      if (request.method === 'GET' && path === '/api/plugin/latest') {
+        const data = await env.PLUGIN_METADATA.get(KV_KEY, 'json');
+        if (!data) {
+          return Response.json(
+            { error: 'No version data available' },
+            { status: 404, headers: corsHeaders }
+          );
+        }
+        return Response.json(data, { headers: corsHeaders });
+      }
+
+      // POST /api/plugin/upload — 上传版本信息（需鉴权）
+      if (request.method === 'POST' && path === '/api/plugin/upload') {
+        // 鉴权：校验 Bearer token
+        const authHeader = request.headers.get('Authorization') || '';
+        const token = authHeader.replace(/^Bearer\s+/i, '');
+
+        if (!token || token !== env.UPLOAD_TOKEN) {
+          return Response.json(
+            { error: 'Unauthorized' },
+            { status: 401, headers: corsHeaders }
+          );
+        }
+
+        // 解析请求体
+        let body;
+        try {
+          body = await request.json();
+        } catch {
+          return Response.json(
+            { error: 'Invalid JSON body' },
+            { status: 400, headers: corsHeaders }
+          );
+        }
+
+        // 校验必填字段
+        const requiredFields = ['version', 'file_name', 'download_url'];
+        for (const field of requiredFields) {
+          if (!body[field]) {
+            return Response.json(
+              { error: `Missing required field: ${field}` },
+              { status: 400, headers: corsHeaders }
+            );
+          }
+        }
+
+        // 字段校验：防止路径穿越和注入
+        if (typeof body.version !== 'string' || body.version.length > 50) {
+          return Response.json({ error: 'Invalid version' }, { status: 400, headers: corsHeaders });
+        }
+        if (typeof body.file_name !== 'string' || body.file_name.includes('..') || body.file_name.includes('/') || body.file_name.length > 200) {
+          return Response.json({ error: 'Invalid file_name' }, { status: 400, headers: corsHeaders });
+        }
+        if (typeof body.download_url !== 'string' || !body.download_url.startsWith('https://') || body.download_url.length > 2000) {
+          return Response.json({ error: 'Invalid download_url' }, { status: 400, headers: corsHeaders });
+        }
+        if (body.sha256 && (typeof body.sha256 !== 'string' || body.sha256.length > 128)) {
+          return Response.json({ error: 'Invalid sha256' }, { status: 400, headers: corsHeaders });
+        }
+        if (body.changelog && typeof body.changelog !== 'string') {
+          return Response.json({ error: 'Invalid changelog' }, { status: 400, headers: corsHeaders });
+        }
+
+        // 写入 KV
+        const metadata = {
+          version: body.version,
+          file_name: body.file_name,
+          download_url: body.download_url,
+          sha256: body.sha256 || '',
+          changelog: body.changelog || '',
+          updated_at: new Date().toISOString(),
+        };
+
+        await env.PLUGIN_METADATA.put(KV_KEY, JSON.stringify(metadata));
+
+        return Response.json(
+          { success: true, version: metadata.version },
+          { status: 200, headers: corsHeaders }
+        );
+      }
+
+      // 404 for unknown routes
+      return Response.json(
+        { error: 'Not found' },
+        { status: 404, headers: corsHeaders }
+      );
+
+    } catch (err) {
+      return Response.json(
+        { error: 'Internal server error', detail: err.message },
+        { status: 500, headers: corsHeaders }
+      );
+    }
+  },
+};

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -5,8 +5,6 @@
  * POST /api/plugin/upload  — 上传版本信息（需 Bearer token 鉴权）
  */
 
-// UPLOAD_TOKEN 通过 wrangler secret put 设置，自 env 参数传入
-
 // KV key
 const KV_KEY = 'plugin:latest';
 
@@ -15,14 +13,12 @@ export default {
     const url = new URL(request.url);
     const path = url.pathname;
 
-    // CORS headers
     const corsHeaders = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     };
 
-    // Handle CORS preflight
     if (request.method === 'OPTIONS') {
       return new Response(null, { headers: corsHeaders });
     }
@@ -42,7 +38,6 @@ export default {
 
       // POST /api/plugin/upload — 上传版本信息（需鉴权）
       if (request.method === 'POST' && path === '/api/plugin/upload') {
-        // 鉴权：校验 Bearer token
         const authHeader = request.headers.get('Authorization') || '';
         const token = authHeader.replace(/^Bearer\s+/i, '');
 
@@ -53,7 +48,6 @@ export default {
           );
         }
 
-        // 解析请求体
         let body;
         try {
           body = await request.json();
@@ -64,26 +58,9 @@ export default {
           );
         }
 
-        // 校验必填字段
-        const requiredFields = ['version', 'file_name', 'download_url'];
-        for (const field of requiredFields) {
-          if (!body[field]) {
-            return Response.json(
-              { error: `Missing required field: ${field}` },
-              { status: 400, headers: corsHeaders }
-            );
-          }
-        }
-
-        // 字段校验：防止路径穿越和注入
-        if (typeof body.version !== 'string' || body.version.length > 50) {
+        // 校验必填字段（只需要 version）
+        if (!body.version || typeof body.version !== 'string' || body.version.length > 50) {
           return Response.json({ error: 'Invalid version' }, { status: 400, headers: corsHeaders });
-        }
-        if (typeof body.file_name !== 'string' || body.file_name.includes('..') || body.file_name.includes('/') || body.file_name.length > 200) {
-          return Response.json({ error: 'Invalid file_name' }, { status: 400, headers: corsHeaders });
-        }
-        if (typeof body.download_url !== 'string' || !body.download_url.startsWith('https://') || body.download_url.length > 2000) {
-          return Response.json({ error: 'Invalid download_url' }, { status: 400, headers: corsHeaders });
         }
         if (body.sha256 && (typeof body.sha256 !== 'string' || body.sha256.length > 128)) {
           return Response.json({ error: 'Invalid sha256' }, { status: 400, headers: corsHeaders });
@@ -95,8 +72,6 @@ export default {
         // 写入 KV
         const metadata = {
           version: body.version,
-          file_name: body.file_name,
-          download_url: body.download_url,
           sha256: body.sha256 || '',
           changelog: body.changelog || '',
           updated_at: new Date().toISOString(),
@@ -110,7 +85,6 @@ export default {
         );
       }
 
-      // 404 for unknown routes
       return Response.json(
         { error: 'Not found' },
         { status: 404, headers: corsHeaders }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "fancy-version-worker"
+main = "src/index.js"
+compatibility_date = "2026-05-30"
+account_id = "867520dfa43947e67f0416d72989a2af"
+
+# KV namespace for storing plugin version metadata
+kv_namespaces = [
+  { binding = "PLUGIN_METADATA", id = "b61c4877e5eb4f4abef9f6308a8e288a" }
+]
+
+routes = [
+  { pattern = "fancy-version.baicaizhale.top", custom_domain = true }
+]


### PR DESCRIPTION
## Summary

- Skill 下载迁移至 fancy-skill.baicaizhale.top，三级级联留底
- 插件更新新建独立 Worker（KV + Bearer 鉴权），CI 自动上传版本信息
- JAR 下载三级级联：fancy.baicaizhale.top/latest -> ghproxy -> GitHub 直连
- 检测到更新后自动下载，不再需要手动 upgrade

## 改动文件

| 文件 | 改动 |
|---|---|
| worker/src/index.js | 新 Worker：GET 版本信息 + POST 上传鉴权 |
| worker/wrangler.toml | Worker 配置 + 自定义域名路由 |
| ConfigManager.java | 新增 Skill/插件更新常量 |
| SkillUpdateManager.java | 三级级联下载 + 自动下载 |
| UpdateManager.java | 重写：Worker API 检查版本 + 三级级联下载 |
| CI-Build-Release.yml | CI 自动上传版本信息到 Worker |
| config.yml | 移除三个 Skill URL 配置项 |

## 注意

需要在 GitHub Actions 添加 Secrets：
- PLUGIN_UPLOAD_TOKEN
- WORKER_VERSION_URL

## Test plan

- Worker 安全测试通过
- Worker GET/POST 接口实测通过
- 自定义域名 fancy-version.baicaizhale.top 绑定生效
- mvn test 通过