### PR TITLE
fix: 修复 #edit 行内替换吃掉行内容，增强配置错误处理

### DIFF
--- a/.github/workflows/CI-Build-Release.yml
+++ b/.github/workflows/CI-Build-Release.yml
@@ -212,7 +212,8 @@ jobs:
             fi
           done
 
-      - name: 上传版本信息到 Worker
+      - name: 上传版本信息到 Worker（仅正式版）
+        if: needs.build.outputs.IS_RELEASE == 'true'
         env:
           PLUGIN_UPLOAD_TOKEN: ${{ secrets.PLUGIN_UPLOAD_TOKEN }}
           WORKER_VERSION_URL: ${{ secrets.WORKER_VERSION_URL }}
@@ -236,44 +237,6 @@ jobs:
 
               echo ""
               echo "版本信息已上传: ${VERSION}"
-              break
-            fi
-          done
-
-      - name: 上传 Release 版本信息（含更新日志）
-        if: needs.build.outputs.IS_RELEASE == 'true'
-        env:
-          PLUGIN_UPLOAD_TOKEN: ${{ secrets.PLUGIN_UPLOAD_TOKEN }}
-          WORKER_VERSION_URL: ${{ secrets.WORKER_VERSION_URL }}
-        run: |
-          for jar in artifacts/FancyHelper-*.jar; do
-            if [[ -f "$jar" ]]; then
-              FILENAME=$(basename "$jar")
-              VERSION="${FILENAME#FancyHelper-}"
-              VERSION="${VERSION%.jar}"
-              SHA256=$(sha256sum "$jar" | cut -d' ' -f1)
-
-              CHANGELOG=$(curl -sL "https://api.github.com/repos/baicaizhale/FancyHelper/releases/tags/v${VERSION}" \
-                | jq -r '.body // empty' 2>/dev/null | head -c 5000 || echo "")
-
-              if [[ -z "$CHANGELOG" && -f "release_body.md" ]]; then
-                CHANGELOG=$(head -c 5000 release_body.md)
-              fi
-
-              echo "上传 Release 版本信息（含更新日志）: ${VERSION}"
-
-              jq -n \
-                --arg version "$VERSION" \
-                --arg sha256 "$SHA256" \
-                --arg changelog "$CHANGELOG" \
-                '{version: $version, sha256: $sha256, changelog: $changelog}' \
-                | curl -s -X POST "${WORKER_VERSION_URL}/api/plugin/upload" \
-                  -H "Authorization: Bearer ${PLUGIN_UPLOAD_TOKEN}" \
-                  -H "Content-Type: application/json" \
-                  -d @-
-
-              echo ""
-              echo "Release 版本信息已上传: ${VERSION}"
               break
             fi
           done

--- a/src/main/java/org/YanPl/FancyHelper.java
+++ b/src/main/java/org/YanPl/FancyHelper.java
@@ -349,20 +349,13 @@ public final class FancyHelper extends JavaPlugin {
             }
         }
         
-        // 如果检测到是 Spigot（非 Paper 及下游），显示警告并禁用自动升级
+        // 如果检测到是 Spigot（非 Paper 及下游），显示警告
         if (!isPaperOrFork && (lowerName.contains("spigot") || lowerName.contains("craftbukkit"))) {
             getLogger().warning("====================");
             getLogger().warning("您正在使用 Spigot 服务端，可能导致一些奇怪的问题。");
             getLogger().warning("您可以考虑转移到 Paper 服务端哦。");
             getLogger().warning("Paper 服务端地址: https://papermc.io/");
             getLogger().warning("====================");
-            
-            // 禁用自动升级功能（Spigot 服务端可能存在兼容性问题）
-            if (configManager.isAutoUpgrade()) {
-                getConfig().set("settings.auto_upgrade", false);
-                configManager.save();
-                getLogger().warning("已自动禁用自动升级功能（auto_upgrade = false），以避免潜在的兼容性问题。");
-            }
         }
     }
 

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -572,7 +572,7 @@ public class CLIManager {
                             }
                             net.md_5.bungee.api.ChatColor starColor = net.md_5.bungee.api.ChatColor.of(BREATHING_HEX[phaseIdx]);
 
-                            // 2. 随机词（每 7 秒切换）
+                            // 2. 随机词 + 打字机效果（每 7 秒切换新词，逐字揭示）
                             Long wordStart = wordStartTimes.get(uuid);
                             String word = currentThinkingWords.get(uuid);
                             if (wordStart == null || word == null || now - wordStart > 7000) {
@@ -580,6 +580,16 @@ public class CLIManager {
                                 currentThinkingWords.put(uuid, word);
                                 wordStartTimes.put(uuid, now);
                             }
+
+                            // 打字机缓动效果 — ease-out cubic，先快后慢，约 3.5s 打完
+                            long wordElapsed = now - wordStart;
+                            double typeDuration = 2000.0;
+                            double progress = Math.min(wordElapsed / typeDuration, 1.0);
+                            double eased = 1 - Math.pow(1 - progress, 3);
+                            int revealIdx = Math.max(1, Math.min((int) Math.round(eased * word.length()), word.length()));
+                            String typewriterWord = word.substring(0, revealIdx);
+                            boolean isFullyRevealed = revealIdx >= word.length();
+                            String suffix = isFullyRevealed ? "... " : "_ ";
 
                             // 3. Token 统计（仅本轮输出，含实时流式累计）
                             DialogueSession session = sessions.get(uuid);
@@ -595,7 +605,7 @@ public class CLIManager {
                             // ActionBar: TextComponent.setColor() 直接用 hex
                             TextComponent comp = new TextComponent(BREATHING_SYMBOLS[phaseIdx] + " ");
                             comp.setColor(starColor);
-                            TextComponent wordComp = new TextComponent(word + "... ");
+                            TextComponent wordComp = new TextComponent(typewriterWord + suffix);
                             wordComp.setColor(WORD_COLOR_BUNGEE);
                             comp.addExtra(wordComp);
                             TextComponent statsComp = new TextComponent(statsSuffix);
@@ -603,7 +613,7 @@ public class CLIManager {
                             comp.addExtra(statsComp);
 
                             // Subtitle: ChatColor.of(hex) + 字符串，其 toString() 产出 §x§R§G§B 格式，sendTitle 无 bug
-                            String subtitleMsg = starColor + BREATHING_SYMBOLS[phaseIdx] + " " + WORD_COLOR_BUNGEE + word + "... "
+                            String subtitleMsg = starColor + BREATHING_SYMBOLS[phaseIdx] + " " + WORD_COLOR_BUNGEE + typewriterWord + suffix
                                 + STATS_COLOR + statsSuffix;
 
                             sendStatusMessage(player, comp, subtitleMsg);

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -75,7 +75,13 @@ public class ConfigManager {
             return;
         }
 
-        FileConfiguration currentConfig = YamlConfiguration.loadConfiguration(configFile);
+        FileConfiguration currentConfig;
+        try {
+            currentConfig = YamlConfiguration.loadConfiguration(configFile);
+        } catch (Exception e) {
+            plugin.getLogger().severe("config.yml 格式错误，跳过版本检查: " + e.getMessage());
+            return;
+        }
         String configVersion = currentConfig.getString("version", "");
         String pluginVersion = plugin.getDescription().getVersion();
 
@@ -214,7 +220,17 @@ public class ConfigManager {
     public void loadConfig() {
         // 确保存在默认配置并读取
         plugin.saveDefaultConfig();
-        plugin.reloadConfig();
+        try {
+            plugin.reloadConfig();
+        } catch (Exception e) {
+            plugin.getLogger().severe("config.yml 格式错误，无法加载配置文件: " + e.getMessage());
+            if (config == null) {
+                // 首次加载失败时，回退到默认空配置
+                config = plugin.getConfig();
+            }
+            // 保留旧 config 对象不变，避免下游读取到空值产生误导性错误
+            return;
+        }
         this.config = plugin.getConfig();
 
         // 清理 config.yml 中可能存在的旧玩家数据（迁移到 playerdata.yml 后）

--- a/src/main/java/org/YanPl/manager/FileWatcherManager.java
+++ b/src/main/java/org/YanPl/manager/FileWatcherManager.java
@@ -83,8 +83,12 @@ public class FileWatcherManager {
             if (!plugin.isEnabled()) return;
             switch (fileName) {
                 case "config.yml":
-                    plugin.getConfigManager().loadConfig();
-                    plugin.getLogger().info("检测到 config.yml 变动，已自动重载。");
+                    try {
+                        plugin.getConfigManager().loadConfig();
+                        plugin.getLogger().info("检测到 config.yml 变动，已自动重载。");
+                    } catch (Exception e) {
+                        plugin.getLogger().severe("重载 config.yml 时出错: " + e.getMessage());
+                    }
                     break;
                 case "playerdata.yml":
                     plugin.getConfigManager().loadPlayerData();

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -784,27 +784,15 @@ public class ToolExecutor {
             newLines.add(lines.get(i));
         }
         
-        // 插入修改后的内容（保留缩进和注释）
+        // 插入修改后的内容（行内替换，保留行内其他部分）
         String[] replacementLines = replacement.split("\n");
         for (int j = 0; j < originalLineCount; j++) {
             String originalLine = lines.get(matchStartIndex + j);
             String newLine;
-            
+
             if (j < replacementLines.length) {
-                // 提取原始行的缩进和注释
-                String indent = extractIndent(originalLine);
-                String comment = extractComment(originalLine);
-                
-                int textEndPos = originalLine.indexOf('#');
-                if (textEndPos == -1) {
-                    textEndPos = originalLine.length();
-                }
-                
-                // 构建新行：缩进 + 新内容 + 注释
-                newLine = indent + replacementLines[j];
-                if (!comment.isEmpty()) {
-                    newLine += comment;
-                }
+                // 行内子串替换：将匹配到的内容替换为新内容，缩进和注释等其余部分自动保留
+                newLine = originalLine.replace(originalLines[j], replacementLines[j]);
             } else {
                 // 如果 replacement 行数少于 original 行数，保留原始行
                 newLine = originalLine;


### PR DESCRIPTION
## 变更内容

### Bug 修复
- **修复 #edit 工具行内替换 bug**（`ToolExecutor.java`）：当 AI 只修改行内一个词时（如 `pro` → `flash`），旧逻辑将整行丢弃后重建，导致行内容丢失。改用 `String.replace()` 行内子串替换，缩进和注释自动保留。
- **移除 Spigot 服务端自动禁用云端更新的逻辑**：不再因为服务端类型自动禁用 `auto_upgrade`。

### 增强
- **配置加载错误处理**（`ConfigManager.java`）：config.yml 格式错误时显示明确错误信息并优雅回退，而非抛异常导致插件崩溃。
- **文件监控容错**（`FileWatcherManager.java`）：config.yml 热重载失败时捕获异常，不影响其他文件监控。
- **ActionBar 打字机效果**（`CLIManager.java`）：思考状态显示加入 ease-out 缓动逐字揭示效果，体验更流畅。

### CI
- **版本信息上传优化**：仅正式版 Release 上传版本信息到 Worker，避免快照版本覆盖。
