### PR TITLE
feat: 分离 Skill 远程安装与更新流程，新增 list-remote/install 命令

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -777,8 +778,10 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             sender.sendMessage(" §7- §b/cli skill load <id> §f: 加载 Skill 到当前对话");
             if (sender.hasPermission("fancyhelper.skill.admin")) {
                 sender.sendMessage(" §7- §b/cli skill reload §f: 重新加载所有 Skill");
-                sender.sendMessage(" §7- §b/cli skill checkupdate §f: 检查 Skill 更新");
-                sender.sendMessage(" §7- §b/cli skill upgrade §f: 下载并安装所有 Skill 更新");
+                sender.sendMessage(" §7- §b/cli skill checkupdate §f: 检查已有 Skill 更新");
+                sender.sendMessage(" §7- §b/cli skill upgrade §f: 下载并安装已有 Skill 更新");
+                sender.sendMessage(" §7- §b/cli skill list-remote §f: 列出远程仓库中可安装的 Skill");
+                sender.sendMessage(" §7- §b/cli skill install <id> §f: 从远程仓库安装指定 Skill");
             }
             return true;
         }
@@ -831,6 +834,25 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                     return true;
                 }
                 plugin.getSkillUpdateManager().downloadUpdates(sender instanceof Player ? (Player) sender : null);
+                break;
+            case "list-remote":
+                if (!sender.hasPermission("fancyhelper.skill.admin")) {
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §c你没有权限执行此操作"));
+                    return true;
+                }
+                handleSkillListRemote(sender);
+                break;
+            case "install":
+                if (!sender.hasPermission("fancyhelper.skill.admin")) {
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §c你没有权限执行此操作"));
+                    return true;
+                }
+                if (args.length < 3) {
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §c请提供要安装的 Skill ID"));
+                    sender.sendMessage("§7用法: /cli skill install <id>");
+                } else {
+                    handleSkillInstall(sender, args[2]);
+                }
                 break;
             default:
                 sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §c未知子命令: " + subCommand));
@@ -903,6 +925,53 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         }
 
         player.sendMessage(ColorUtil.translateCustomColors("§aSkill §7> §f" + skill.getMetadata().getName()));
+    }
+
+    /**
+     * 处理 list-remote 子命令：列出远程仓库中可安装的 Skill
+     */
+    private void handleSkillListRemote(CommandSender sender) {
+        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f正在获取远程 Skill 列表..."));
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            Map<String, String> remote = plugin.getSkillUpdateManager().listRemoteSkills();
+
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (remote.isEmpty()) {
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §e远程仓库中没有新的 Skill 可安装"));
+                    return;
+                }
+
+                sender.sendMessage(ColorUtil.translateCustomColors("§6========== 可安装的远程 Skill =========="));
+                for (Map.Entry<String, String> entry : remote.entrySet()) {
+                    sender.sendMessage(" §7- §b" + entry.getKey() + " §7v" + entry.getValue());
+                }
+                sender.sendMessage(ColorUtil.translateCustomColors("§6========================================="));
+                sender.sendMessage("§7使用 §b/cli skill install <id> §7安装");
+            });
+        });
+    }
+
+    /**
+     * 处理 install 子命令：安装远程 Skill
+     */
+    private void handleSkillInstall(CommandSender sender, String skillId) {
+        if (plugin.getSkillManager().hasSkill(skillId)) {
+            sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §eSkill §b" + skillId + " §e已安装"));
+            return;
+        }
+
+        sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f开始安装 §b" + skillId + "§f..."));
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            boolean success = plugin.getSkillUpdateManager().installSkill(skillId, sender instanceof Player ? (Player) sender : null);
+            if (!success) {
+                // installSkill 已经发送了具体错误消息，这里只补充
+                if (sender != null && !(sender instanceof Player)) {
+                    sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §cSkill 安装失败"));
+                }
+            }
+        });
     }
 
     private void handleNotice(CommandSender sender) {
@@ -1123,6 +1192,8 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 skillSubCommands.add("reload");
                 skillSubCommands.add("checkupdate");
                 skillSubCommands.add("upgrade");
+                skillSubCommands.add("list-remote");
+                skillSubCommands.add("install");
             }
             return skillSubCommands.stream()
                     .filter(s -> s.startsWith(args[1].toLowerCase()))

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -535,6 +535,7 @@ public class CLIManager {
      */
     private void startThinkingTask() {
         new BukkitRunnable() {
+            @SuppressWarnings("null")
             @Override
             public void run() {
                 if (!plugin.isEnabled()) {

--- a/src/main/java/org/YanPl/manager/SkillUpdateManager.java
+++ b/src/main/java/org/YanPl/manager/SkillUpdateManager.java
@@ -135,6 +135,72 @@ public class SkillUpdateManager implements Listener {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> doDownload(sender));
     }
 
+    // ==================== 远程技能浏览与安装 ====================
+
+    /**
+     * 获取远程仓库中本地未安装的 Skill 列表
+     * @return skillId -> version 的 Map
+     */
+    public Map<String, String> listRemoteSkills() {
+        Map<String, String> available = new LinkedHashMap<>();
+        try {
+            JsonObject manifest = fetchManifest();
+            if (manifest == null || !manifest.has("skills")) return available;
+
+            JsonObject skillsObj = manifest.getAsJsonObject("skills");
+            for (Map.Entry<String, JsonElement> entry : skillsObj.entrySet()) {
+                String id = entry.getKey();
+                if (!skillManager.hasSkill(id)) {
+                    JsonObject remoteSkill = entry.getValue().getAsJsonObject();
+                    String version = getJsonString(remoteSkill, "version");
+                    available.put(id, version != null ? version : "1.0.0");
+                }
+            }
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "[SkillUpdate] 获取远程列表失败", e);
+        }
+        return available;
+    }
+
+    /**
+     * 从远程安装指定 Skill
+     * @param skillId 要安装的 Skill ID
+     * @param sender 接收通知的玩家，可为 null
+     * @return 是否安装成功
+     */
+    public boolean installSkill(String skillId, Player sender) {
+        if (skillManager.hasSkill(skillId)) {
+            notify(sender, "§eSkill §b" + skillId + " §e已安装，无需重复安装");
+            return false;
+        }
+
+        JsonObject manifest = fetchManifest();
+        if (manifest == null || !manifest.has("skills")) {
+            notify(sender, "§c无法获取远程 Skill 清单");
+            return false;
+        }
+
+        JsonObject skillsObj = manifest.getAsJsonObject("skills");
+        if (!skillsObj.has(skillId)) {
+            notify(sender, "§c远程仓库中不存在 Skill: " + skillId);
+            return false;
+        }
+
+        String remoteVersion = getJsonString(skillsObj.getAsJsonObject(skillId), "version");
+        notify(sender, "§f正在安装 §b" + skillId + " §fv" + (remoteVersion != null ? remoteVersion : "?") + "§f...");
+
+        boolean success = downloadSkillFile(skillId);
+        if (success) {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                skillManager.reloadSkills();
+                notify(sender, "§aSkill §b" + skillId + " §a安装成功！");
+            });
+        } else {
+            notify(sender, "§cSkill §b" + skillId + " §c安装失败");
+        }
+        return success;
+    }
+
     // ==================== 核心逻辑 ====================
 
     /**
@@ -180,16 +246,6 @@ public class SkillUpdateManager implements Listener {
                     pendingUpdates.put(id, remoteVersion);
                 }
                 checkedCount++;
-            }
-
-            // 本地没有但远端有的技能（新技能）
-            for (Map.Entry<String, JsonElement> entry : skillsObj.entrySet()) {
-                String id = entry.getKey();
-                if (!skillManager.hasSkill(id)) {
-                    JsonObject remoteSkill = entry.getValue().getAsJsonObject();
-                    String remoteVersion = getJsonString(remoteSkill, "version");
-                    pendingUpdates.put(id, remoteVersion != null ? remoteVersion : "1.0.0");
-                }
             }
 
             hasUpdates = !pendingUpdates.isEmpty();
@@ -306,6 +362,18 @@ public class SkillUpdateManager implements Listener {
     }
 
     // ==================== 工具方法 ====================
+
+    /**
+     * 获取并解析远程 manifest.json
+     */
+    private JsonObject fetchManifest() {
+        String body = fetchWithFallback(
+                getPrimaryUrl("manifest.json"),
+                getMirrorUrl("manifest.json"),
+                getDirectUrl("manifest.json"));
+        if (body == null) return null;
+        return JsonParser.parseString(body).getAsJsonObject();
+    }
 
     private void notify(Player player, String text) {
         if (player != null) {

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -1838,37 +1838,6 @@ public class ToolExecutor {
     }
 
     /**
-     * 提取行的缩进（前导空格和制表符）
-     * @param line 原始行
-     * @return 缩进字符串
-     */
-    private String extractIndent(String line) {
-        StringBuilder indent = new StringBuilder();
-        for (int i = 0; i < line.length(); i++) {
-            char c = line.charAt(i);
-            if (c == ' ' || c == '\t') {
-                indent.append(c);
-            } else {
-                break;
-            }
-        }
-        return indent.toString();
-    }
-
-    /**
-     * 提取行的注释（# 及其后的内容）
-     * @param line 原始行
-     * @return 注释字符串（包括 #），如果没有注释则返回空字符串
-     */
-    private String extractComment(String line) {
-        int commentIndex = line.indexOf('#');
-        if (commentIndex != -1) {
-            return line.substring(commentIndex);
-        }
-        return "";
-    }
-
-    /**
      * 去掉行号前缀（格式：数字: ）
      * @param line 带行号的行，如 "94: enabled: true"
      * @return 去掉行号后的行，如 "enabled: true"


### PR DESCRIPTION
## 改动

将 Skill 的"更新已有"和"安装新技能"两个逻辑分离，改为用户主动选择安装。

### 后端 (SkillUpdateManager.java)
- **移除** `doCheck` 中自动将远程新 skill 加入待下载列表的逻辑
- **新增** `listRemoteSkills()` — 从远程 manifest 获取本地未安装的 skill 列表
- **新增** `installSkill(skillId, sender)` — 验证 manifest → 下载指定 skill → reloadSkills
- **新增** `fetchManifest()` — 复用三级回退请求，抽取为独立方法

### 命令 (CLICommand.java)
- **新增** `/cli skill list-remote` — 列出远程仓库中可安装的 skill（需 `fancyhelper.skill.admin`）
- **新增** `/cli skill install <id>` — 从远程安装指定 skill（需 `fancyhelper.skill.admin`）
- 更新 skill 帮助文本和 tab 补全

### 效果变更
- `checkupdate`/`upgrade` 不再自动拉取新 skill，只更新已安装的
- 新 skill 需要通过 `list-remote` 查看 → `install <id>` 主动安装