### PR TITLE
chore: 移除 preset 残留代码

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -18,7 +18,6 @@ FancyHelper is here to solve this problem. Once installed, you can talk directly
 - **Pre-execution Confirmation** — AI-generated commands require manual confirmation (`y`/`n`) by default to prevent accidents.
 - **YOLO Mode** — Tired of confirming? After agreeing to the terms, most commands execute automatically, though high-risk operations like `op`, `ban`, and `stop` still require approval.
 - **Real-time Status Bar** — The Action Bar displays what the AI is currently doing (Thinking / Executing / Waiting for confirmation).
-- **Built-in Wiki Search** — Includes documentation presets for LuckPerms, EssentialsX, WorldEdit, and more. It can even search the web if not found locally.
 - **Feedback Loop** — The output of executed commands is fed back to the AI. If something fails, the AI can correct itself.
 - **Automatic Config Updates** — No need to manually edit configs during upgrades; it handles them automatically.
 - **Anti-Loop Protection** — Automatically intercepts the AI if it starts repeating operations or making excessive calls.

--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -376,7 +376,6 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         if (!(sender instanceof Player)) {
             sender.sendMessage(ChatColor.AQUA + "=== FancyHelper 状态 ===");
             sender.sendMessage(ChatColor.WHITE + "已索引命令: " + ChatColor.YELLOW + plugin.getWorkspaceIndexer().getIndexedCommands().size());
-            sender.sendMessage(ChatColor.WHITE + "已索引预设: " + ChatColor.YELLOW + plugin.getWorkspaceIndexer().getIndexedPresets().size());
             sender.sendMessage(ChatColor.WHITE + "已加载 Skills: " + ChatColor.YELLOW + plugin.getSkillManager().getSkillCount());
             sender.sendMessage(ChatColor.WHITE + "CLI 模式玩家: " + ChatColor.YELLOW + plugin.getCliManager().getActivePlayersCount());
             sender.sendMessage(ChatColor.WHITE + "插件版本: " + ChatColor.YELLOW + plugin.getDescription().getVersion());

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -2750,7 +2750,7 @@ public class CLIManager {
         String toolCall = "";
 
         // 定义已知工具列表
-        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         boolean foundTool = false;
@@ -2910,7 +2910,7 @@ public class CLIManager {
         cleanResponse = cleanResponse.replaceAll("(?i)^思考过程:.*?\n", "");
         cleanResponse = cleanResponse.trim();
         
-        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#getpreset", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
+        List<String> knownTools = Arrays.asList("#start", "#end", "#exit", "#run", "#ask", "#search", "#skill", "#unloadskill", "#list", "#read", "#edit", "#todo", "#remember", "#forget", "#edit_memory", "#webread");
 
         int currentPos = 0;
         while (currentPos < cleanResponse.length()) {

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -1,7 +1,6 @@
 package org.YanPl.manager;
 
 import org.YanPl.FancyHelper;
-import org.YanPl.util.ResourceUtil;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -111,13 +110,8 @@ public class ConfigManager {
 
             // 2. 释放新配置
             configFile.delete();
-            File presetDir = new File(plugin.getDataFolder(), "preset");
-            if (presetDir.exists()) {
-                deleteDirectory(presetDir);
-            }
 
             plugin.saveDefaultConfig();
-            ResourceUtil.releaseResources(plugin, "preset/", true, ".txt");
 
             // 3. 把旧配置写入新配置
             FileConfiguration newConfig = YamlConfiguration.loadConfiguration(configFile);
@@ -200,21 +194,6 @@ public class ConfigManager {
             }
         }
         plugin.getLogger().warning("等待 ReloadService 关闭超时，将尝试强制释放 JAR");
-    }
-
-    private void deleteDirectory(File directory) {
-        File[] files = directory.listFiles();
-        if (files != null) {
-            for (File file : files) {
-                if (file.isDirectory()) {
-                    deleteDirectory(file);
-                } else {
-                    file.delete();
-                }
-            }
-        }
-        // 删除目录自身
-        directory.delete();
     }
 
     public void loadConfig() {

--- a/src/main/java/org/YanPl/manager/PromptManager.java
+++ b/src/main/java/org/YanPl/manager/PromptManager.java
@@ -88,8 +88,7 @@ public class PromptManager {
         // 2. 【单命令执行】#run 工具一次只能执行一条命令，禁止使用 && 或 ; 连接多个命令
         // 3. 【工具位置】工具调用必须另起一行，不得在正文或注释中调用
         // 4. 【格式规范】工具名和冒号之间不要有空格，命令参数不要带斜杠 /
-        // 5. 【强制读预设】执行任务前必须先检查 Available Presets 列表，存在则调用 #getpreset
-        // 6. 【禁止猜测命令】没有预设且没有搜索结果时，禁止执行命令，必须先搜索
+        // 5. 【禁止猜测命令】没有搜索结果时，禁止执行命令，必须先搜索
         sb.append("[Core Constraints] (Violations cause parsing failures — follow strictly)\n\n");
 
         sb.append("1. [Single Tool Call] Each response may contain ONLY ONE tool call.\n");
@@ -101,9 +100,7 @@ public class PromptManager {
 
         sb.append("4. [Format] No space between tool name and colon. No leading slash / in arguments.\n\n");
 
-        sb.append("5. [Read Preset First] Check Available Presets list before any task. If the preset exists, call #getpreset first.\n\n");
-
-        sb.append("6. [Never Guess Commands] If no preset and no search result, do NOT execute commands. Search first.\n\n");
+        sb.append("5. [Never Guess Commands] If no search result, do NOT execute commands. Search first.\n\n");
 
         // 正确示例 / 错误示例（精简为最典型的两个，避免负面示例过多干扰模型）
         sb.append("Example:\n");

--- a/src/main/java/org/YanPl/manager/ToolExecutor.java
+++ b/src/main/java/org/YanPl/manager/ToolExecutor.java
@@ -109,9 +109,6 @@ public class ToolExecutor {
             case "#edit":
                 handleFileTool(player, "edit", args, session);
                 break;
-            case "#getpreset":
-                handleGetTool(player, args);
-                break;
             case "#skill":
                 handleSkillTool(player, args, session);
                 break;
@@ -239,7 +236,7 @@ public class ToolExecutor {
         } else if (!lowerToolName.equals("#search") && !lowerToolName.equals("#run") &&
             !lowerToolName.equals("#end") && !lowerToolName.equals("#list") &&
             !lowerToolName.equals("#read") && !lowerToolName.equals("#todo") &&
-            !lowerToolName.equals("#getpreset") && !lowerToolName.equals("#webread")) {
+            !lowerToolName.equals("#webread")) {
             // 对 #webread 隐藏此显示，因为 #webread 会在 executeWebReader 中显示更详细的信息
             player.sendMessage(ChatColor.GRAY + "〇 " + toolName);
         }
@@ -347,24 +344,6 @@ public class ToolExecutor {
      */
     private void handleFileTool(Player player, String type, String args, DialogueSession session) {
         UUID uuid = player.getUniqueId();
-
-        if ("read".equals(type)) {
-            String pathArg = args == null ? "" : args.trim();
-            String[] parts = pathArg.split("\\s+");
-            String path = parts.length > 0 ? parts[0] : "";
-            try {
-                String cleaned = path.startsWith("/") || path.startsWith("\\") ? path.substring(1) : path;
-                java.io.File worldRoot = org.bukkit.Bukkit.getWorldContainer();
-                java.io.File target = new java.io.File(worldRoot, cleaned).getCanonicalFile();
-                java.io.File presetDir = new java.io.File(plugin.getDataFolder(), "preset").getCanonicalFile();
-                if (target.getPath().startsWith(presetDir.getPath() + java.io.File.separator) || target.equals(presetDir)) {
-                    String name = target.getName();
-                    player.sendMessage(org.bukkit.ChatColor.YELLOW + "提示: 预设文件请使用 #getpreset: " + name);
-                    cliManager.feedbackToAI(player, "#read_result: 错误 - 预设文件请使用 #getpreset: " + name);
-                    return;
-                }
-            } catch (Exception ignored) {}
-        }
 
         // #ls 和 #read 不需要确认，直接执行
         if ("ls".equals(type) || "read".equals(type)) {
@@ -1155,29 +1134,6 @@ public class ToolExecutor {
         if (type == short.class) return (short) 0;
         if (type == char.class) return '\0';
         return null;
-    }
-
-    /**
-     * 处理 #getpreset 工具
-     */
-    private void handleGetTool(Player player, String fileName) {
-        // 显示正在读取预设的信息
-        player.sendMessage(ChatColor.GRAY + "〇 正在读取预设...");
-        cliManager.setGenerating(player.getUniqueId(), false, CLIManager.GenerationStatus.EXECUTING_TOOL);
-        
-        File presetFile = new File(plugin.getDataFolder(), "preset/" + fileName);
-        if (!presetFile.exists()) {
-            cliManager.feedbackToAI(player, "#get_result: 文件不存在");
-            return;
-        }
-
-        try {
-            List<String> lines = Files.readAllLines(presetFile.toPath());
-            String content = String.join("\n", lines);
-            cliManager.feedbackToAI(player, "#get_result: " + content);
-        } catch (IOException e) {
-            cliManager.feedbackToAI(player, "#get_result: 读取文件失败 - " + e.getMessage());
-        }
     }
 
     /**

--- a/src/main/java/org/YanPl/manager/WorkspaceIndexer.java
+++ b/src/main/java/org/YanPl/manager/WorkspaceIndexer.java
@@ -1,12 +1,10 @@
 package org.YanPl.manager;
 
 import org.YanPl.FancyHelper;
-import org.YanPl.util.ResourceUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.SimpleCommandMap;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,20 +13,18 @@ import java.util.stream.Collectors;
 
 public class WorkspaceIndexer {
     /**
-     * 工作区索引器：用于索引服务器上可用的命令以及插件内的预设文件列表。
+     * 工作区索引器：用于索引服务器上可用的命令。
      */
     private final FancyHelper plugin;
     private List<String> indexedCommands = new ArrayList<>();
-    private List<String> indexedPresets = new ArrayList<>();
 
     public WorkspaceIndexer(FancyHelper plugin) {
         this.plugin = plugin;
     }
 
     public void indexAll() {
-        // 同步执行命令与预设索引（调用方可选择异步）
+        // 同步执行命令索引（调用方可选择异步）
         indexCommands();
-        indexPresets();
     }
 
     @SuppressWarnings("unchecked")
@@ -56,33 +52,7 @@ public class WorkspaceIndexer {
         }
     }
 
-    public void indexPresets() {
-        indexedPresets.clear();
-        File presetDir = new File(plugin.getDataFolder(), "preset");
-        if (!presetDir.exists()) {
-            presetDir.mkdirs();
-        }
-        
-        ResourceUtil.releaseResources(plugin, "preset/", false, ".txt");
-        
-        File[] files = presetDir.listFiles();
-        if (files != null) {
-            for (File file : files) {
-                if (file.isFile() && file.getName().endsWith(".txt")) {
-                    indexedPresets.add(file.getName());
-                }
-            }
-        }
-        if (plugin.getConfigManager().isDebug()) {
-            plugin.getLogger().info("已索引 " + indexedPresets.size() + " 个预设文件。");
-        }
-    }
-
     public List<String> getIndexedCommands() {
         return indexedCommands;
-    }
-
-    public List<String> getIndexedPresets() {
-        return indexedPresets;
     }
 }

--- a/src/main/java/org/YanPl/util/ResourceUtil.java
+++ b/src/main/java/org/YanPl/util/ResourceUtil.java
@@ -12,7 +12,7 @@ import java.util.jar.JarFile;
 public class ResourceUtil {
 
     /**
-     * 资源工具类：负责将 jar 内嵌的资源释放到插件数据目录（如 preset 文件）。
+     * 资源工具类：负责将 jar 内嵌的资源释放到插件数据目录。
      */
 
     public static void releaseResources(FancyHelper plugin, String resourceDir, boolean replace, String extension) {

--- a/src/main/resources/skills/house-builder/skill.md
+++ b/src/main/resources/skills/house-builder/skill.md
@@ -11,6 +11,5 @@ auto_trigger: true
 source: "house-builder"
 author: "FancyHelper Team"
 version: "0.0.1"
-categories:
-  - "preset"
+categories: []
 ---


### PR DESCRIPTION
## 概要
移除 `#getpreset` 工具及整个 preset 功能链路的残留代码。由于 jar 内无 preset 资源文件，该功能一直处于空转状态。

## 变更内容
- 删除 `ToolExecutor` 中的 `#getpreset` case 和 `handleGetTool` 方法
- 删除 `WorkspaceIndexer` 中的 `indexPresets()` / `getIndexedPresets()` 方法
- 删除 `ConfigManager` 中重载时对 preset 目录的清理和释放逻辑
- 删除 `CLIManager` 已知工具列表中的 `#getpreset`
- 删除 `PromptManager` 中"强制读预设"约束，第6条顺延为第5条
- 删除 `CLICommand` 状态显示中的 preset 计数
- 删除 `README_EN.md` 中 Built-in Wiki Search 描述
- 清理 `house-builder/skill.md` 中 preset 分类
- 清理 `ResourceUtil` 注释及废弃的 `deleteDirectory` 方法

## 影响
净删 101 行，无功能影响。