### PR TITLE
feat: 添加声音反馈功能

### DIFF
--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -128,6 +128,13 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 }
                 Player player = (Player) sender;
                 return handlePlayerSubCommand(player, subCommand, args);
+            case "sound":
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage(ChatColor.RED + "该子命令仅限玩家使用。");
+                    return true;
+                }
+                player = (Player) sender;
+                return handlePlayerSubCommand(player, subCommand, args);
             case "skill":
                 if (!sender.hasPermission("fancyhelper.skill.use")) {
                     sender.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f你没有权限使用 Skill 命令。"));
@@ -175,6 +182,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
         sender.sendMessage(" §7- §b/cli exit §f: 退出 CLI 模式");
         sender.sendMessage(" §7- §b/cli compress §f: 使用AI智能压缩当前会话上下文");
         sender.sendMessage(" §7- §b/cli streaming §f: 切换流式输出开关");
+        sender.sendMessage(" §7- §b/cli sound §f: 切换声音反馈开关");
         sender.sendMessage(" §7- §b/cli skill §f: Skill 管理命令");
         sender.sendMessage(" §7  §b/cli skill list §f: 列出所有 Skill");
         sender.sendMessage(" §7  §b/cli skill info <id> §f: 查看 Skill 详情");
@@ -313,6 +321,11 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 return true;
             case "compress":
                 plugin.getCliManager().compressContext(player, args.length > 1 ? args[1] : null);
+                return true;
+            case "sound":
+                boolean disabled = plugin.getConfigManager().isPlayerSoundDisabled(player.getUniqueId());
+                plugin.getConfigManager().setPlayerSoundDisabled(player.getUniqueId(), !disabled);
+                player.sendMessage(ChatColor.GREEN + "声音反馈已" + (disabled ? "开启" : "关闭"));
                 return true;
         }
         return true;
@@ -1152,7 +1165,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
                 "read", "set", "settings", "tools", "display", "streaming", "toggle",
                 "notice", "retry", "todo", "memory", "mem", "confirm",
                 "cancel", "agree", "thought", "select", "exempt_anti_loop",
-                "stop", "exit", "download", "help", "lib", "compress", "skill"
+                "stop", "exit", "download", "help", "lib", "compress", "skill", "sound"
             ));
             return subCommands.stream()
                     .filter(s -> s.startsWith(args[0].toLowerCase()))

--- a/src/main/java/org/YanPl/command/CLICommand.java
+++ b/src/main/java/org/YanPl/command/CLICommand.java
@@ -275,7 +275,7 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "streaming":
                 boolean currentStreaming = plugin.getConfigManager().isPlayerStreamingEnabled(player);
                 plugin.getConfigManager().setPlayerStreamingEnabled(player, !currentStreaming);
-                player.sendMessage(ChatColor.GREEN + "流式输出已" + (!currentStreaming ? "开启" : "关闭"));
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f流式输出已" + (!currentStreaming ? "开启" : "关闭")));
                 handleSettings(player);
                 return true;
             case "select":
@@ -325,7 +325,8 @@ public class CLICommand implements CommandExecutor, TabCompleter {
             case "sound":
                 boolean disabled = plugin.getConfigManager().isPlayerSoundDisabled(player.getUniqueId());
                 plugin.getConfigManager().setPlayerSoundDisabled(player.getUniqueId(), !disabled);
-                player.sendMessage(ChatColor.GREEN + "声音反馈已" + (disabled ? "开启" : "关闭"));
+                player.sendMessage(ColorUtil.translateCustomColors("§zFancyHelper§b§r §7> §f声音反馈已" + (disabled ? "开启" : "关闭")));
+                handleSettings(player);
                 return true;
         }
         return true;
@@ -502,7 +503,21 @@ public class CLICommand implements CommandExecutor, TabCompleter {
 
         player.sendMessage("");
 
-        // 4. Management Buttons
+        // 5. Sound Toggle
+        boolean soundDisabled = plugin.getConfigManager().isPlayerSoundDisabled(player.getUniqueId());
+        TextComponent soundLine = new TextComponent(ColorUtil.translateCustomColors("&7  Sound: "));
+        TextComponent soundVal = new TextComponent(ColorUtil.translateCustomColors(soundDisabled ? "&cDisabled" : "&aEnabled"));
+        soundLine.addExtra(soundVal);
+        soundLine.addExtra("  ");
+        TextComponent soundBtn = new TextComponent(ColorUtil.translateCustomColors("&8[ &7Toggle &8]"));
+        soundBtn.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/cli sound"));
+        soundBtn.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(ChatColor.GRAY + "点击切换声音反馈")));
+        soundLine.addExtra(soundBtn);
+        player.spigot().sendMessage(soundLine);
+
+        player.sendMessage("");
+
+        // 6. Management Buttons
         TextComponent toolsLine = new TextComponent("  ");
         
         TextComponent toolsBtn = new TextComponent(ColorUtil.translateCustomColors("&8[ &6Tools &8]"));

--- a/src/main/java/org/YanPl/manager/CLIManager.java
+++ b/src/main/java/org/YanPl/manager/CLIManager.java
@@ -1074,6 +1074,7 @@ public class CLIManager {
         if (session != null) {
             sessions.put(uuid, session);
         }
+        playFeedbackSound(player, "cli_enter");
     }
 
     /**
@@ -1186,7 +1187,8 @@ public class CLIManager {
         }
 
         sendExitMessage(player);
-        
+        playFeedbackSound(player, "cli_exit");
+
         // 保存会话历史 - 仅在插件卸载时保存
         // DialogueSession session = sessions.get(uuid);
         // if (session != null) {
@@ -2408,6 +2410,7 @@ public class CLIManager {
                     }
                     streamedOutputTokens.remove(uuid);
                     checkTokenWarning(player, session);
+                    playFeedbackSound(player, "ai_complete");
                 }
             });
         });
@@ -2434,9 +2437,10 @@ public class CLIManager {
                 isGenerating.put(uuid, false);
                 generationStates.put(uuid, GenerationStatus.ERROR);
                 generationStartTimes.remove(uuid);
+                playFeedbackSound(player, "ai_error");
             });
         });
-        
+
         // 估算本轮输入的 prompt tokens 并记入 session
         String systemPrompt = promptManager.getSystemPromptForSession(player, matchedSkills, session.getMode());
         String modelName = plugin.getConfigManager().getCloudflareModel();
@@ -2497,6 +2501,7 @@ public class CLIManager {
                 } else {
                     checkTokenWarning(player, session);
                 }
+                playFeedbackSound(player, "ai_complete");
             });
         }
     }
@@ -2506,10 +2511,11 @@ public class CLIManager {
         String systemPrompt = promptManager.getSystemPromptForSession(player, matchedSkills,
                 nsSession != null ? nsSession.getMode() : DialogueSession.Mode.NORMAL);
         AIResponse response = ai.chat(sessions.get(player.getUniqueId()), systemPrompt);
-        
+
         if (!plugin.isEnabled()) return;
         Bukkit.getScheduler().runTask(plugin, () -> {
             handleAIResponse(player, response);
+            playFeedbackSound(player, "ai_complete");
         });
     }
 
@@ -2534,6 +2540,7 @@ public class CLIManager {
 
         TextComponent playerMsg = new TextComponent(ChatColor.GRAY + "◇ " + message);
         player.spigot().sendMessage(playerMsg);
+        playFeedbackSound(player, "user_input");
 
         if (plugin.getConfigManager().isDebug()) {
             plugin.getLogger().info("[CLI] 会话 " + player.getName() + " - 历史记录大小: " + session.getHistory().size() + ", 预计 Token: " + calculateTotalEstimatedTokens(player, session));
@@ -2614,6 +2621,7 @@ public class CLIManager {
                     recordThinkingTime(uuid);
                     generationStates.put(uuid, GenerationStatus.ERROR);
                     generationStartTimes.remove(uuid);
+                    playFeedbackSound(player, "ai_error");
                     // 立即清除动作栏
                     player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(""));
                     // 移除导致失败的消息，防止污染后续对话
@@ -2644,6 +2652,7 @@ public class CLIManager {
                     recordThinkingTime(uuid);
                     generationStates.put(uuid, GenerationStatus.ERROR);
                     generationStartTimes.remove(uuid);
+                    playFeedbackSound(player, "ai_error");
                     // 立即清除动作栏
                     player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(""));
                     // 移除导致失败的消息，防止污染后续对话
@@ -3342,6 +3351,7 @@ public class CLIManager {
                             AIResponse response = new AIResponse(completeText,
                                 (thought != null && !thought.isEmpty()) ? thought : null);
                             handleAIResponse(player, response, true);
+                            playFeedbackSound(player, "ai_complete");
                         });
                     });
 
@@ -3366,6 +3376,7 @@ public class CLIManager {
                             isGenerating.put(uuid, false);
                             generationStates.put(uuid, GenerationStatus.ERROR);
                             generationStartTimes.remove(uuid);
+                            playFeedbackSound(player, "ai_error");
                             player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(""));
                         });
                     });
@@ -3393,7 +3404,10 @@ public class CLIManager {
                         AIResponse response = new AIResponse(completeText,
                             (thought != null && !thought.isEmpty()) ? thought : null);
                         if (!plugin.isEnabled()) return;
-                        Bukkit.getScheduler().runTask(plugin, () -> handleAIResponse(player, response, true));
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            handleAIResponse(player, response, true);
+                            playFeedbackSound(player, "ai_complete");
+                        });
                     }
                 } else {
                     AIResponse response = ai.chat(session, systemPrompt);
@@ -3401,6 +3415,7 @@ public class CLIManager {
                     if (!plugin.isEnabled()) return;
                     Bukkit.getScheduler().runTask(plugin, () -> {
                         handleAIResponse(player, response);
+                        playFeedbackSound(player, "ai_complete");
                     });
                 }
             } catch (IOException e) {
@@ -3434,6 +3449,7 @@ public class CLIManager {
                     recordThinkingTime(uuid);
                     generationStates.put(uuid, GenerationStatus.ERROR);
                     generationStartTimes.remove(uuid);
+                    playFeedbackSound(player, "ai_error");
                     // 立即清除动作栏
                     player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(""));
                     // 移除导致失败的消息，防止污染后续对话
@@ -3463,6 +3479,7 @@ public class CLIManager {
                     recordThinkingTime(uuid);
                     generationStates.put(uuid, GenerationStatus.ERROR);
                     generationStartTimes.remove(uuid);
+                    playFeedbackSound(player, "ai_error");
                     // 立即清除动作栏
                     player.spigot().sendMessage(net.md_5.bungee.api.ChatMessageType.ACTION_BAR, new TextComponent(""));
                     // 移除导致失败的消息，防止污染后续对话
@@ -3686,6 +3703,23 @@ public class CLIManager {
      * 流式输出时，裁掉末尾未闭合的 Markdown 格式标记，
      * 防止 ** 等标记在闭合前就泄露给玩家。
      */
+    private void playFeedbackSound(Player player, String soundKey) {
+        if (!plugin.getConfigManager().isSoundEnabled()) return;
+        if (plugin.getConfigManager().isPlayerSoundDisabled(player.getUniqueId())) return;
+        String sound;
+        switch (soundKey) {
+            case "ai_complete": sound = plugin.getConfigManager().getSoundAiComplete(); break;
+            case "ai_error": sound = plugin.getConfigManager().getSoundAiError(); break;
+            case "cli_enter": sound = plugin.getConfigManager().getSoundCliEnter(); break;
+            case "cli_exit": sound = plugin.getConfigManager().getSoundCliExit(); break;
+            case "user_input": sound = plugin.getConfigManager().getSoundUserInput(); break;
+            default: return;
+        }
+        if (sound != null && !sound.isEmpty() && !sound.equalsIgnoreCase("none")) {
+            player.playSound(player.getLocation(), sound, 0.5f, 1.0f);
+        }
+    }
+
     private String stripIncompleteFormatting(String text) {
         if (text == null || text.isEmpty()) return text;
         // 统计 ** 出现次数，奇数表示最后一个 ** 未闭合

--- a/src/main/java/org/YanPl/manager/ConfigManager.java
+++ b/src/main/java/org/YanPl/manager/ConfigManager.java
@@ -614,6 +614,41 @@ public class ConfigManager {
         savePlayerData();
     }
 
+    // ========== 声音反馈配置 ==========
+
+    public boolean isSoundEnabled() {
+        return config.getBoolean("sounds.enabled", true);
+    }
+
+    public String getSoundAiComplete() {
+        return config.getString("sounds.ai_complete", "block.note_block.hat");
+    }
+
+    public String getSoundAiError() {
+        return config.getString("sounds.ai_error", "block.note_block.bass");
+    }
+
+    public String getSoundCliEnter() {
+        return config.getString("sounds.cli_enter", "block.note_block.chime");
+    }
+
+    public String getSoundCliExit() {
+        return config.getString("sounds.cli_exit", "block.note_block.bell");
+    }
+
+    public String getSoundUserInput() {
+        return config.getString("sounds.user_input", "block.wooden_button.click_on");
+    }
+
+    public boolean isPlayerSoundDisabled(java.util.UUID uuid) {
+        return playerData.getBoolean("sound_disabled." + uuid.toString(), false);
+    }
+
+    public void setPlayerSoundDisabled(java.util.UUID uuid, boolean disabled) {
+        playerData.set("sound_disabled." + uuid.toString(), disabled);
+        savePlayerData();
+    }
+
     public void save() {
         try {
             config.save(new File(plugin.getDataFolder(), "config.yml"));

--- a/src/main/java/org/YanPl/manager/GuiManager.java
+++ b/src/main/java/org/YanPl/manager/GuiManager.java
@@ -119,8 +119,11 @@ public class GuiManager implements Listener {
 
         // 4. 状态显示位置 (ActionBar/Subtitle)
         updateDisplayPosItem(inv, player);
-        
-        // 5. 关闭按钮
+
+        // 5. 声音开关
+        updateSoundItem(inv, player);
+
+        // 6. 关闭按钮
         ItemStack closeItem = createItem(Material.BARRIER, ColorUtil.translateCustomColors("&c&l关闭菜单"), 
                 ColorUtil.translateCustomColors("&7点击关闭此菜单"));
         inv.setItem(26, closeItem);
@@ -193,6 +196,27 @@ public class GuiManager implements Listener {
         inv.setItem(16, item);
     }
 
+    private void updateSoundItem(Inventory inv, Player player) {
+        boolean disabled = plugin.getConfigManager().isPlayerSoundDisabled(player.getUniqueId());
+        ItemStack item;
+        if (disabled) {
+            item = createItem(Material.GRAY_DYE, ColorUtil.translateCustomColors("&7&l声音反馈: 关闭"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"),
+                    ColorUtil.translateCustomColors("&7当前声音反馈已 &c关闭"),
+                    "",
+                    ColorUtil.translateCustomColors("&e▸ 点击开启声音反馈"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"));
+        } else {
+            item = createItem(Material.LIME_DYE, ColorUtil.translateCustomColors("&a&l声音反馈: 开启"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"),
+                    ColorUtil.translateCustomColors("&7当前声音反馈已 &a开启"),
+                    "",
+                    ColorUtil.translateCustomColors("&e▸ 点击关闭声音反馈"),
+                    ColorUtil.translateCustomColors("&8&m------------------------"));
+        }
+        inv.setItem(18, item);
+    }
+
     private ItemStack createItem(Material material, String name, String... lore) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
@@ -261,6 +285,12 @@ public class GuiManager implements Listener {
             player.performCommand("cli display");
             // 刷新图标
             updateDisplayPosItem(event.getClickedInventory(), player);
+            player.playSound(player.getLocation(), "ui.button.click", 1, 1);
+        }
+        // 声音开关
+        else if (slot == 18) {
+            player.performCommand("cli sound");
+            updateSoundItem(event.getClickedInventory(), player);
             player.playSound(player.getLocation(), "ui.button.click", 1, 1);
         }
         // 关闭

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -127,3 +127,18 @@ notice:
   show_on_join: true
   # 每隔多久从服务器拉取公告（单位：分钟），默认 5 分钟
   refresh_interval: 5
+
+# 声音反馈配置
+sounds:
+  # 全局开关，设为 false 则所有声音反馈都不播放
+  enabled: true
+  # AI 回复完成时的音效
+  ai_complete: "block.note_block.hat"
+  # AI 调用出错时的音效
+  ai_error: "block.note_block.bass"
+  # 进入 CLI 模式时的音效
+  cli_enter: "block.note_block.chime"
+  # 退出 CLI 模式时的音效
+  cli_exit: "block.note_block.bell"
+  # 玩家发送消息时的音效
+  user_input: "block.wooden_button.click_on"


### PR DESCRIPTION
## 概述

为 FancyHelper 添加声音反馈系统，在关键操作时播放 Minecraft 原版音效，提升用户交互体验。

## 改动内容

### 新增功能
- **AI 完成回复**: 播放 `block.note_block.hat`（短促打击声）
- **AI 调用出错**: 播放 `block.note_block.bass`（低沉提示）
- **进入/退出 CLI**: 分别播放 `block.note_block.chime` / `block.note_block.bell`
- **玩家发送消息**: 播放 `block.wooden_button.click_on`（木头闷响）
- **新命令 `/cli sound`**: 玩家可单独切换声音开关
- **GUI 开关**: `/cli settings` 和 `/cli gui` 中均可控制声音
- **可配置**: 所有音效在 `config.yml` 的 `sounds` 节中可自定义或禁用（设为 `"none"`）

### 修复
- 统一 `/cli settings` 中 toggle 类消息的格式，使用 `§zFancyHelper§b§r §7> §f` 前缀

## 配置示例

```yaml
sounds:
  enabled: true
  ai_complete: "block.note_block.hat"
  ai_error: "block.note_block.bass"
  cli_enter: "block.note_block.chime"
  cli_exit: "block.note_block.bell"
  user_input: "block.wooden_button.click_on"
```

## 测试

- 所有音效均为 Minecraft 原版内置，无需额外资源包
- 玩家可通过 `/cli sound` 或个人设置界面开关
- 管理员可通过 `config.yml` 全局禁用或自定义音效